### PR TITLE
Remove enable/disable calls for GlStateManager

### DIFF
--- a/src/main/java/com/gtnewhorizons/modularui/api/GlStateManager.java
+++ b/src/main/java/com/gtnewhorizons/modularui/api/GlStateManager.java
@@ -801,14 +801,10 @@ public class GlStateManager {
         }
 
         public void setState(boolean state) {
-            if (state != this.currentState) {
-                this.currentState = state;
-
-                if (state) {
-                    GL11.glEnable(this.capability);
-                } else {
-                    GL11.glDisable(this.capability);
-                }
+            if (state) {
+                GL11.glEnable(this.capability);
+            } else {
+                GL11.glDisable(this.capability);
             }
         }
     }


### PR DESCRIPTION
This should fix weird shadow with GUI.
`GlStateManager` is still not purged due to `RepeatingDrawable` using it.