### PR TITLE
Add support for scientific notation (2e3 = 2000) and suffixes like k, m, b, ...

### DIFF
--- a/addon.gradle
+++ b/addon.gradle
@@ -1,3 +1,9 @@
 compileJava {
     options.encoding = "UTF-8"
 }
+test {
+    useJUnitPlatform()
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1704751096
+//version: 1705357285
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -122,6 +122,7 @@ propertyDefaultIfUnset("modrinthProjectId", "")
 propertyDefaultIfUnset("modrinthRelations", "")
 propertyDefaultIfUnset("curseForgeProjectId", "")
 propertyDefaultIfUnset("curseForgeRelations", "")
+propertyDefaultIfUnset("versionPattern", "")
 propertyDefaultIfUnset("minimizeShadowedDependencies", true)
 propertyDefaultIfUnset("relocateShadowedDependencies", true)
 // Deprecated properties (kept for backwards compat)
@@ -370,6 +371,7 @@ catch (Exception ignored) {
 // Pulls version first from the VERSION env and then git tag
 String identifiedVersion
 String versionOverride = System.getenv("VERSION") ?: null
+boolean checkVersion = false
 try {
     // Produce a version based on the tag, or for branches something like 0.2.2-configurable-maven-and-extras.38+43090270b6-dirty
     if (versionOverride == null) {
@@ -388,6 +390,8 @@ try {
             }
         } else if (isDirty) {
             identifiedVersion += "-${branchName}+${gitDetails.gitHash}-dirty"
+        } else {
+            checkVersion = true
         }
     } else {
         identifiedVersion = versionOverride
@@ -409,6 +413,8 @@ ext {
 
 if (identifiedVersion == versionOverride) {
     out.style(Style.Failure).text('Override version to ').style(Style.Identifier).text(modVersion).style(Style.Failure).println('!\7')
+} else if (checkVersion && versionPattern && !(identifiedVersion ==~ versionPattern)) {
+    throw new GradleException("Invalid version: '$identifiedVersion' does not match version pattern '$versionPattern'")
 }
 
 group = "com.github.GTNewHorizons"
@@ -428,18 +434,31 @@ minecraft {
         for (f in replaceGradleTokenInFile.split(',')) {
             tagReplacementFiles.add f
         }
+        out.style(Style.Info).text('replaceGradleTokenInFile is deprecated! Consider using generateGradleTokenClass.').println()
     }
     if (gradleTokenModId) {
-        injectedTags.put gradleTokenModId, modId
+        if (replaceGradleTokenInFile) {
+            injectedTags.put gradleTokenModId, modId
+        } else {
+            out.style(Style.Failure).text('gradleTokenModId is deprecated! The field will no longer be generated.').println()
+        }
     }
     if (gradleTokenModName) {
-        injectedTags.put gradleTokenModName, modName
+        if (replaceGradleTokenInFile) {
+            injectedTags.put gradleTokenModName, modName
+        } else {
+            out.style(Style.Failure).text('gradleTokenModName is deprecated! The field will no longer be generated.').println()
+        }
     }
     if (gradleTokenVersion) {
         injectedTags.put gradleTokenVersion, modVersion
     }
     if (gradleTokenGroupName) {
-        injectedTags.put gradleTokenGroupName, modGroup
+        if (replaceGradleTokenInFile) {
+            injectedTags.put gradleTokenGroupName, modGroup
+        } else {
+            out.style(Style.Failure).text('gradleTokenGroupName is deprecated! The field will no longer be generated.').println()
+        }
     }
     if (enableGenericInjection.toBoolean()) {
         injectMissingGenerics.set(true)

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -11,4 +11,7 @@ dependencies {
         exclude group:"com.github.GTNewHorizons", module:"ModularUI"
     }
     compileOnly("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-310-GTNH:dev") { transitive = false }
+
+    testImplementation(platform('org.junit:junit-bom:5.9.2'))
+    testImplementation('org.junit.jupiter:junit-jupiter')
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,12 +5,12 @@ dependencies {
 
     api("com.github.GTNewHorizons:NotEnoughItems:2.5.4-GTNH:dev")
 
-    compileOnly("com.github.GTNewHorizons:Hodgepodge:2.4.8:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.45.25:dev") {
+    compileOnly("com.github.GTNewHorizons:Hodgepodge:2.4.12:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.45.47:dev") {
         transitive = false
         exclude group:"com.github.GTNewHorizons", module:"ModularUI"
     }
-    compileOnly("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-310-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-312-GTNH:dev") { transitive = false }
 
     testImplementation(platform('org.junit:junit-bom:5.9.2'))
     testImplementation('org.junit.jupiter:junit-jupiter')

--- a/src/main/java/com/gtnewhorizons/modularui/api/math/MathExpression.java
+++ b/src/main/java/com/gtnewhorizons/modularui/api/math/MathExpression.java
@@ -56,7 +56,8 @@ public class MathExpression {
             }
         }
 
-        for (int i = 1; i < parsed.size() - 1; i++) {
+        // ^ is right-associative: a^b^c = a^(b^c)
+        for (int i = parsed.size() - 2; i > 0; i--) {
             Object obj = parsed.get(i);
             if (obj == Operator.POWER) {
                 Double left = (Double) parsed.get(i - 1);

--- a/src/main/java/com/gtnewhorizons/modularui/api/math/MathExpression.java
+++ b/src/main/java/com/gtnewhorizons/modularui/api/math/MathExpression.java
@@ -44,7 +44,7 @@ public class MathExpression {
 
         for (int i = 1; i < parsed.size() - 1; i++) {
             Object obj = parsed.get(i);
-            if (obj == Operator.EXPONENT) {
+            if (obj == Operator.SCIENTIFIC) {
                 Double left = (Double) parsed.get(i - 1);
                 Double right = (Double) parsed.get(i + 1);
                 Double result = left * Math.pow(10, right);
@@ -198,7 +198,7 @@ public class MathExpression {
                         parsed.add(parse(builder.toString(), onFailReturn));
                         builder.delete(0, builder.length());
                     }
-                    parsed.add(Operator.EXPONENT);
+                    parsed.add(Operator.SCIENTIFIC);
                     break;
                 }
                 case 'k':
@@ -284,7 +284,7 @@ public class MathExpression {
         DIVIDE("/"),
         MOD("%"),
         POWER("^"),
-        EXPONENT("e");
+        SCIENTIFIC("e");
 
         public final String sign;
 

--- a/src/main/java/com/gtnewhorizons/modularui/api/math/MathExpression.java
+++ b/src/main/java/com/gtnewhorizons/modularui/api/math/MathExpression.java
@@ -24,101 +24,107 @@ public class MathExpression {
             Object value = parsed.get(0);
             return value instanceof Double ? (double) value : onFailReturn;
         }
-        Double lastNum = null;
-        for (int i = 0; i < parsed.size(); i++) {
+
+        if (Operator.MINUS == parsed.get(0)) {
+            parsed.remove(0);
+            parsed.set(0, -(Double) parsed.get(0));
+        }
+
+        for (int i = 1; i < parsed.size(); i++) {
             Object obj = parsed.get(i);
-            if (lastNum == null && obj instanceof Double) {
-                lastNum = (Double) obj;
-                continue;
-            }
-            if (obj == Operator.POWER) {
-                Double newNum = Math.pow(lastNum, (Double) parsed.get(i + 1));
+            if (obj instanceof Suffix) {
+                Double left = (Double) parsed.get(i - 1);
+                Double result = left * ((Suffix) obj).multiplier;
                 parsed.remove(i - 1);
                 parsed.remove(i - 1);
-                parsed.remove(i - 1);
-                parsed.add(i - 1, newNum);
-                lastNum = newNum;
+                parsed.add(i - 1, result);
                 i--;
-                continue;
-            }
-            lastNum = null;
-        }
-        if (lastNum != null) {
-            lastNum = null;
-        }
-        if (parsed.size() > 1) {
-            for (int i = 0; i < parsed.size(); i++) {
-                Object obj = parsed.get(i);
-                if (lastNum == null && obj instanceof Double) {
-                    lastNum = (Double) obj;
-                    continue;
-                }
-                if (obj == Operator.MULTIPLY) {
-                    Double newNum = lastNum * (Double) parsed.get(i + 1);
-                    parsed.remove(i - 1);
-                    parsed.remove(i - 1);
-                    parsed.remove(i - 1);
-                    parsed.add(i - 1, newNum);
-                    lastNum = newNum;
-                    i--;
-                    continue;
-                }
-                if (obj == Operator.DIVIDE) {
-                    Double newNum = lastNum / (Double) parsed.get(i + 1);
-                    parsed.remove(i - 1);
-                    parsed.remove(i - 1);
-                    parsed.remove(i - 1);
-                    parsed.add(i - 1, newNum);
-                    lastNum = newNum;
-                    i--;
-                    continue;
-                }
-                if (obj == Operator.MOD) {
-                    Double newNum = lastNum % (Double) parsed.get(i + 1);
-                    parsed.remove(i - 1);
-                    parsed.remove(i - 1);
-                    parsed.remove(i - 1);
-                    parsed.add(i - 1, newNum);
-                    lastNum = newNum;
-                    i--;
-                    continue;
-                }
-                lastNum = null;
-            }
-            if (lastNum != null) {
-                lastNum = null;
             }
         }
-        if (parsed.size() > 1) {
-            for (int i = 0; i < parsed.size(); i++) {
-                Object obj = parsed.get(i);
-                if (lastNum == null && obj instanceof Double) {
-                    lastNum = (Double) obj;
-                    continue;
-                }
-                if (obj == Operator.PLUS) {
-                    Double newNum = lastNum + (Double) parsed.get(i + 1);
-                    parsed.remove(i - 1);
-                    parsed.remove(i - 1);
-                    parsed.remove(i - 1);
-                    parsed.add(i - 1, newNum);
-                    lastNum = newNum;
-                    i--;
-                    continue;
-                }
-                if (obj == Operator.MINUS) {
-                    Double newNum = lastNum - (Double) parsed.get(i + 1);
-                    parsed.remove(i - 1);
-                    parsed.remove(i - 1);
-                    parsed.remove(i - 1);
-                    parsed.add(i - 1, newNum);
-                    lastNum = newNum;
-                    i--;
-                    continue;
-                }
-                lastNum = null;
+
+        for (int i = 1; i < parsed.size() - 1; i++) {
+            Object obj = parsed.get(i);
+            if (obj == Operator.EXPONENT) {
+                Double left = (Double) parsed.get(i - 1);
+                Double right = (Double) parsed.get(i + 1);
+                Double result = left * Math.pow(10, right);
+                parsed.remove(i - 1);
+                parsed.remove(i - 1);
+                parsed.remove(i - 1);
+                parsed.add(i - 1, result);
+                i--;
             }
         }
+
+        for (int i = 1; i < parsed.size() - 1; i++) {
+            Object obj = parsed.get(i);
+            if (obj == Operator.POWER) {
+                Double left = (Double) parsed.get(i - 1);
+                Double right = (Double) parsed.get(i + 1);
+                Double result = Math.pow(left, right);
+                parsed.remove(i - 1);
+                parsed.remove(i - 1);
+                parsed.remove(i - 1);
+                parsed.add(i - 1, result);
+                i--;
+            }
+        }
+
+        for (int i = 1; i < parsed.size() - 1; i++) {
+            Object obj = parsed.get(i);
+            if (obj == Operator.MULTIPLY) {
+                Double left = (Double) parsed.get(i - 1);
+                Double right = (Double) parsed.get(i + 1);
+                Double result = left * right;
+                parsed.remove(i - 1);
+                parsed.remove(i - 1);
+                parsed.remove(i - 1);
+                parsed.add(i - 1, result);
+                i--;
+            } else if (obj == Operator.DIVIDE) {
+                Double left = (Double) parsed.get(i - 1);
+                Double right = (Double) parsed.get(i + 1);
+                Double result = left / right;
+                parsed.remove(i - 1);
+                parsed.remove(i - 1);
+                parsed.remove(i - 1);
+                parsed.add(i - 1, result);
+                i--;
+            } else if (obj == Operator.MOD) {
+                Double left = (Double) parsed.get(i - 1);
+                Double right = (Double) parsed.get(i + 1);
+                Double result = left % right;
+                parsed.remove(i - 1);
+                parsed.remove(i - 1);
+                parsed.remove(i - 1);
+                parsed.add(i - 1, result);
+                i--;
+            }
+        }
+
+        for (int i = 1; i < parsed.size() - 1; i++) {
+            Object obj = parsed.get(i);
+            if (obj == Operator.PLUS) {
+                Double left = (Double) parsed.get(i - 1);
+                Double right = (Double) parsed.get(i + 1);
+                Double result = left + right;
+                parsed.remove(i - 1);
+                parsed.remove(i - 1);
+                parsed.remove(i - 1);
+                parsed.add(i - 1, result);
+                i--;
+            } else if (obj == Operator.MINUS) {
+                Double left = (Double) parsed.get(i - 1);
+                Double right = (Double) parsed.get(i + 1);
+                Double result = left - right;
+                parsed.remove(i - 1);
+                parsed.remove(i - 1);
+                parsed.remove(i - 1);
+                parsed.add(i - 1, result);
+                i--;
+            }
+        }
+
         if (parsed.size() != 1) {
             throw new IllegalStateException("Calculated expr has more than 1 result. " + parsed);
         }
@@ -133,6 +139,11 @@ public class MathExpression {
         for (int i = 0; i < expr.length(); i++) {
             char c = expr.charAt(i);
             switch (c) {
+                case ' ':
+                case ',':
+                case '_':
+                    break;
+
                 case '+': {
                     if (builder.length() > 0) {
                         parsed.add(parse(builder.toString(), onFailReturn));
@@ -181,6 +192,54 @@ public class MathExpression {
                     parsed.add(Operator.POWER);
                     break;
                 }
+                case 'e':
+                case 'E': {
+                    if (builder.length() > 0) {
+                        parsed.add(parse(builder.toString(), onFailReturn));
+                        builder.delete(0, builder.length());
+                    }
+                    parsed.add(Operator.EXPONENT);
+                    break;
+                }
+                case 'k':
+                case 'K': {
+                    if (builder.length() > 0) {
+                        parsed.add(parse(builder.toString(), onFailReturn));
+                        builder.delete(0, builder.length());
+                    }
+                    parsed.add(Suffix.THOUSAND);
+                    break;
+                }
+                case 'm':
+                case 'M': {
+                    if (builder.length() > 0) {
+                        parsed.add(parse(builder.toString(), onFailReturn));
+                        builder.delete(0, builder.length());
+                    }
+                    parsed.add(Suffix.MILLION);
+                    break;
+                }
+                case 'b':
+                case 'B':
+                case 'g':
+                case 'G': {
+                    if (builder.length() > 0) {
+                        parsed.add(parse(builder.toString(), onFailReturn));
+                        builder.delete(0, builder.length());
+                    }
+                    parsed.add(Suffix.BILLION);
+                    break;
+                }
+                case 't':
+                case 'T': {
+                    if (builder.length() > 0) {
+                        parsed.add(parse(builder.toString(), onFailReturn));
+                        builder.delete(0, builder.length());
+                    }
+                    parsed.add(Suffix.TRILLION);
+                    break;
+                }
+
                 default:
                     builder.append(c);
             }
@@ -188,26 +247,23 @@ public class MathExpression {
         if (builder.length() > 0) {
             parsed.add(parse(builder.toString(), onFailReturn));
         }
-        if (parsed.size() >= 2 && parsed.get(0) == Operator.MINUS && parsed.get(1) instanceof Double) {
-            parsed.add(0, 0.0);
+
+        if (parsed.isEmpty()) return DEFAULT;
+
+        Object prevToken = null;
+        Object thisToken = null;
+        for (int i = 0; i < parsed.size(); ++i) {
+            prevToken = thisToken;
+            thisToken = parsed.get(i);
+
+            if (prevToken == null && (thisToken instanceof Double || Operator.MINUS == thisToken)) continue;
+            if (prevToken instanceof Double && (thisToken instanceof Operator || thisToken instanceof Suffix)) continue;
+            if (prevToken instanceof Operator && thisToken instanceof Double) continue;
+            if (prevToken instanceof Suffix && (thisToken instanceof Operator || thisToken instanceof Suffix)) continue;
+            return DEFAULT;
         }
-        boolean shouldBeOperator = false;
-        for (Object object : parsed) {
-            if (shouldBeOperator) {
-                if (!(object instanceof Operator)) {
-                    return DEFAULT;
-                }
-                shouldBeOperator = false;
-            } else {
-                if (!(object instanceof Double)) {
-                    return DEFAULT;
-                }
-                shouldBeOperator = true;
-            }
-        }
-        while (parsed.get(parsed.size() - 1) instanceof Operator) {
-            parsed.remove(parsed.size() - 1);
-        }
+        if (thisToken instanceof Operator) return DEFAULT;
+
         return parsed;
     }
 
@@ -227,7 +283,8 @@ public class MathExpression {
         MULTIPLY("*"),
         DIVIDE("/"),
         MOD("%"),
-        POWER("^");
+        POWER("^"),
+        EXPONENT("e");
 
         public final String sign;
 
@@ -238,6 +295,20 @@ public class MathExpression {
         @Override
         public String toString() {
             return sign;
+        }
+    }
+
+    public enum Suffix {
+
+        THOUSAND(1_000D),
+        MILLION(1_000_000D),
+        BILLION(1_000_000_000D),
+        TRILLION(1_000_000_000_000D);
+
+        public final double multiplier;
+
+        Suffix(double multiplier) {
+            this.multiplier = multiplier;
         }
     }
 }

--- a/src/main/java/com/gtnewhorizons/modularui/common/widget/textfield/BaseTextFieldWidget.java
+++ b/src/main/java/com/gtnewhorizons/modularui/common/widget/textfield/BaseTextFieldWidget.java
@@ -60,6 +60,20 @@ public class BaseTextFieldWidget extends Widget implements IWidgetParent, Intera
     public static final Pattern WHOLE_NUMS = Pattern.compile("-?[0-9]*([+\\-*/%^][0-9]*)*");
 
     public static final Pattern DECIMALS = Pattern.compile("[0-9]*(\\.[0-9]*)?([+\\-*/%^][0-9]*(\\.[0-9]*)?)*");
+
+    /**
+     * A mathematical expression. Supported:
+     * <ul>
+     * <li>digits: 0..9</li>
+     * <li>decimal point: .</li>
+     * <li>thousands separators: , _ [space]</li>
+     * <li>arithmetic operations: + - * / % ^</li>
+     * <li>decimal exponent: e E</li>
+     * <li>decimal suffixes: k K m M b B g G t T</li>
+     * </ul>
+     */
+    public static final Pattern MATH_EXPRESSION = Pattern.compile("[0-9.,_ +\\-*/%^eEkKmMgGbBtT]*");
+
     /**
      * alphabets
      */

--- a/src/main/java/com/gtnewhorizons/modularui/common/widget/textfield/TextFieldWidget.java
+++ b/src/main/java/com/gtnewhorizons/modularui/common/widget/textfield/TextFieldWidget.java
@@ -262,7 +262,7 @@ public class TextFieldWidget extends BaseTextFieldWidget implements ISyncedWidge
     }
 
     public TextFieldWidget setNumbersLong(Function<Long, Long> validator) {
-        setPattern(WHOLE_NUMS);
+        setPattern(MATH_EXPRESSION);
         setValidator(val -> {
             long num;
             if (val.isEmpty()) {
@@ -276,7 +276,7 @@ public class TextFieldWidget extends BaseTextFieldWidget implements ISyncedWidge
     }
 
     public TextFieldWidget setNumbers(Function<Integer, Integer> validator) {
-        setPattern(WHOLE_NUMS);
+        setPattern(MATH_EXPRESSION);
         return setValidator(val -> {
             int num;
             if (val.isEmpty()) {
@@ -289,7 +289,7 @@ public class TextFieldWidget extends BaseTextFieldWidget implements ISyncedWidge
     }
 
     public TextFieldWidget setNumbersDouble(Function<Double, Double> validator) {
-        setPattern(DECIMALS);
+        setPattern(MATH_EXPRESSION);
         return setValidator(val -> {
             double num;
             if (val.isEmpty()) {

--- a/src/main/java/com/gtnewhorizons/modularui/test/TestTile.java
+++ b/src/main/java/com/gtnewhorizons/modularui/test/TestTile.java
@@ -31,6 +31,7 @@ import com.gtnewhorizons.modularui.api.math.Alignment;
 import com.gtnewhorizons.modularui.api.math.Color;
 import com.gtnewhorizons.modularui.api.math.CrossAxisAlignment;
 import com.gtnewhorizons.modularui.api.math.MainAxisAlignment;
+import com.gtnewhorizons.modularui.api.math.MathExpression;
 import com.gtnewhorizons.modularui.api.math.Pos2d;
 import com.gtnewhorizons.modularui.api.math.Size;
 import com.gtnewhorizons.modularui.api.screen.ITileWithModularUI;
@@ -78,6 +79,7 @@ public class TestTile extends TileEntity implements ITileWithModularUI {
     private int progress = 0;
     private int ticks = 0;
     private float sliderValue = 0;
+    private long longValue = 0;
     private int serverCounter = 0;
     private static final AdaptableUITexture DISPLAY = AdaptableUITexture
             .of("modularui:gui/background/display", 143, 75, 2);
@@ -175,6 +177,12 @@ public class TestTile extends TileEntity implements ITileWithModularUI {
                     serverCounter = 0;
                     changeableWidget.notifyChangeServer();
                 }).setShiftClickPriority(0).setPos(10, 30))
+                .addChild(
+                        new TextFieldWidget().setGetter(() -> String.valueOf(longValue))
+                                .setSetter(val -> longValue = (long) MathExpression.parseMathExpression(val))
+                                .setNumbersLong(val -> val).setTextColor(Color.WHITE.dark(1))
+                                .setTextAlignment(Alignment.CenterLeft).setScrollBar()
+                                .setBackground(DISPLAY.withOffset(-2, -2, 4, 4)).setSize(92, 20).setPos(10, 50))
                 .addChild(
                         SlotWidget.phantom(phantomInventory, 1).setShiftClickPriority(1).setIgnoreStackSizeLimit(true)
                                 .setControlsAmount(true).setPos(28, 30))

--- a/src/test/java/com/gtnewhorizons/modularui/api/math/MathExpressionTest.java
+++ b/src/test/java/com/gtnewhorizons/modularui/api/math/MathExpressionTest.java
@@ -51,7 +51,7 @@ class MathExpressionTest {
     }
 
     @Test
-    void ExponentBasic_Test() {
+    void ScientificBasic_Test() {
         assertEquals(2000, MathExpression.parseMathExpression("2e3"));
         assertEquals(3000, MathExpression.parseMathExpression("3E3"));
         assertEquals(4000, MathExpression.parseMathExpression("4 e 3"));
@@ -61,7 +61,7 @@ class MathExpressionTest {
     }
 
     @Test
-    void ExponentArithmetic_Test() {
+    void ScientificArithmetic_Test() {
         assertEquals(4000, MathExpression.parseMathExpression("2*2e3"));
         assertEquals(6000, MathExpression.parseMathExpression("2e3 * 3"));
         assertEquals(-200, MathExpression.parseMathExpression("-2e2"));

--- a/src/test/java/com/gtnewhorizons/modularui/api/math/MathExpressionTest.java
+++ b/src/test/java/com/gtnewhorizons/modularui/api/math/MathExpressionTest.java
@@ -1,0 +1,110 @@
+package com.gtnewhorizons.modularui.api.math;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class MathExpressionTest {
+
+    @Test
+    void NumbersBasic_Test() {
+        assertEquals(42, MathExpression.parseMathExpression("42"));
+        assertEquals(42, MathExpression.parseMathExpression("  42  "));
+
+        assertEquals(123456, MathExpression.parseMathExpression("123,456"));
+        assertEquals(123456, MathExpression.parseMathExpression("123 456"));
+        assertEquals(123456, MathExpression.parseMathExpression("123_456"));
+
+        assertEquals(123.456, MathExpression.parseMathExpression("123.456"));
+    }
+
+    @Test
+    void ArithmeticBasic_Test() {
+        assertEquals(5, MathExpression.parseMathExpression("2+3"));
+        assertEquals(-1, MathExpression.parseMathExpression("2-3"));
+        assertEquals(6, MathExpression.parseMathExpression("2*3"));
+        assertEquals(2, MathExpression.parseMathExpression("6/3"));
+        assertEquals(1, MathExpression.parseMathExpression("7%3"));
+        assertEquals(8, MathExpression.parseMathExpression("2^3"));
+
+        assertEquals(5, MathExpression.parseMathExpression("2 + 3"));
+    }
+
+    @Test
+    void ArithmeticPriority_Test() {
+        assertEquals(4, MathExpression.parseMathExpression("2+3-1"));
+        assertEquals(14, MathExpression.parseMathExpression("2+3*4"));
+        assertEquals(10, MathExpression.parseMathExpression("2*3+4"));
+        assertEquals(7, MathExpression.parseMathExpression("2^3-1"));
+        assertEquals(13, MathExpression.parseMathExpression("1+2^3+4"));
+    }
+
+    @Test
+    void UnaryZero_Test() {
+        assertEquals(-5, MathExpression.parseMathExpression("-5"));
+        assertEquals(-3, MathExpression.parseMathExpression("-5+2"));
+        assertEquals(-7, MathExpression.parseMathExpression("-5-2"));
+        assertEquals(-10, MathExpression.parseMathExpression("-5*2"));
+        assertEquals(-2.5, MathExpression.parseMathExpression("-5/2"));
+        assertEquals(-1, MathExpression.parseMathExpression("-5%2"));
+        assertEquals(25, MathExpression.parseMathExpression("-5^2")); // ! this is (-5)^2, not -(5^2).
+    }
+
+    @Test
+    void ExponentBasic_Test() {
+        assertEquals(2000, MathExpression.parseMathExpression("2e3"));
+        assertEquals(3000, MathExpression.parseMathExpression("3E3"));
+        assertEquals(4000, MathExpression.parseMathExpression("4 e 3"));
+        assertEquals(5600, MathExpression.parseMathExpression("5.6e3"));
+        assertEquals(70_000, MathExpression.parseMathExpression("700e2"));
+        assertEquals(8, MathExpression.parseMathExpression("8e0"));
+    }
+
+    @Test
+    void ExponentArithmetic_Test() {
+        assertEquals(4000, MathExpression.parseMathExpression("2*2e3"));
+        assertEquals(6000, MathExpression.parseMathExpression("2e3 * 3"));
+        assertEquals(-200, MathExpression.parseMathExpression("-2e2"));
+        assertEquals(1024, MathExpression.parseMathExpression("2^1e1"));
+
+        // Not supported, but shouldn't fail. (2e2)e2 = 200e2 = 20_000.
+        assertEquals(20_000, MathExpression.parseMathExpression("2e2e2"));
+    }
+
+    @Test
+    void SuffixesBasic_Test() {
+        assertEquals(2000, MathExpression.parseMathExpression("2k"));
+        assertEquals(3000, MathExpression.parseMathExpression("3K"));
+        assertEquals(4_000_000, MathExpression.parseMathExpression("4m"));
+        assertEquals(5_000_000, MathExpression.parseMathExpression("5M"));
+        assertEquals(6_000_000_000D, MathExpression.parseMathExpression("6b"));
+        assertEquals(7_000_000_000D, MathExpression.parseMathExpression("7B"));
+        assertEquals(8_000_000_000D, MathExpression.parseMathExpression("8g"));
+        assertEquals(9_000_000_000D, MathExpression.parseMathExpression("9G"));
+        assertEquals(10_000_000_000_000D, MathExpression.parseMathExpression("10t"));
+        assertEquals(11_000_000_000_000D, MathExpression.parseMathExpression("11T"));
+
+        assertEquals(2050, MathExpression.parseMathExpression("2.05k"));
+        assertEquals(50, MathExpression.parseMathExpression("0.05k"));
+        assertEquals(3000, MathExpression.parseMathExpression("3 k"));
+    }
+
+    @Test
+    void SuffixesArithmetic_Test() {
+        assertEquals(2005, MathExpression.parseMathExpression("2k+5"));
+        assertEquals(2005, MathExpression.parseMathExpression("5+2k"));
+        assertEquals(4000, MathExpression.parseMathExpression("2k*2"));
+        assertEquals(4000, MathExpression.parseMathExpression("2*2k"));
+        assertEquals(-2000, MathExpression.parseMathExpression("-2k"));
+
+        assertEquals(3_000_000, MathExpression.parseMathExpression("3kk"));
+        assertEquals(4_000_000_000D, MathExpression.parseMathExpression("4kkk"));
+
+        // Not supported, but shouldn't fail.
+        assertEquals(6_000_000_000D, MathExpression.parseMathExpression("6km"));
+        assertEquals(500_000, MathExpression.parseMathExpression("0.5ke3"));
+
+        // Please don't do this.
+        assertEquals(20_000_000_000D, MathExpression.parseMathExpression("2e0.01k"));
+    }
+}

--- a/src/test/java/com/gtnewhorizons/modularui/api/math/MathExpressionTest.java
+++ b/src/test/java/com/gtnewhorizons/modularui/api/math/MathExpressionTest.java
@@ -37,6 +37,9 @@ class MathExpressionTest {
         assertEquals(10, MathExpression.parseMathExpression("2*3+4"));
         assertEquals(7, MathExpression.parseMathExpression("2^3-1"));
         assertEquals(13, MathExpression.parseMathExpression("1+2^3+4"));
+
+        // a^b^c = a^(b^c)
+        assertEquals(262_144, MathExpression.parseMathExpression("4^3^2"));
     }
 
     @Test


### PR DESCRIPTION
This PR adds support for the following operations in numeric text fields:

* Scientific notation: `2e3` parses into 2,000.

* Common suffixes for powers of 1000:
  * k, K for a thousand: `2k` parses into 2,000.
  * m, M for a million: `2m` parses into 2,000,000.
  * b, B or g, G for a billion: `2b` parses into 2,000,000,000.
  * t, T for a trillion: `2t` parses into 2,000,000,000,000.

All of the above are case-insensitive, so both `2e3` and `2E3` mean 2,000. Same for all the suffixes.

Negative exponents (`2e-3` as 0.002) are **not** supported, for now. Is there anywhere this would be useful?

The suffixes can be "stacked", so for example `2kk` is 2,000,000. Even though this is probably the only common use (nobody uses 2mk to mean 2,000,000,000), technically any combination works as a multiplier.

Non-integer significant digits parse correctly, so both `1.5e3` and `1.5k` mean 1,500.

The text field now also allows the user to input thousands separators: `,`, `_`, or ` ` (space). However those are just silently ignored and not checked for sanity. So `10,000` and `1,0_0,,00` both parse into 10,000. This *should* be i18n friendly (for locales that use `,` as a decimal point and `.` or ` ` as thousands separators), as the method defers to Java standard functions for parsing decimal numbers; although I haven't tested this.

Everything remains compatible with already existing support for evaluating mathematical expressions with operators `+`, `-`, `*`, `/`, `%`, `^`. Though the evaluation code has been slightly streamlined and modified to support the new suffixes.

This should "just work" everywhere if an UI asks for a numeric field using `TextFieldWidget.setNumbers` [`double`,`long`]; or at least if something is using `MathExpression.parseMathExpression`. I have tested this specifically with GT5 covers. If somebody is cooking up their own number validator somewhere, no promises.

The main purpose of this change is to allow the player to more easily configure covers and other UIs, which frequently refer to large numbers. For example, setting an energy detector cover to emit when stored power is above `400000000` EU can easily be mistyped; with this change the player can simply type `400M` instead.

Resolves https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14900.

Finally, I would also like to display the number in the text field with thousands separators. However, right now, this is explicitly disabled (https://github.com/GTNewHorizons/ModularUI/blob/master/src/main/java/com/gtnewhorizons/modularui/common/widget/textfield/BaseTextFieldWidget.java#L89). I am curious if there is a reason for this (for example, some UI doing their own validation and relying on the text field value to be actually `-?[0-9]+`), or if it can be safely turned on. Once again, this would be much clearer when inputting large numbers.