### PR TITLE
Fix parsing in locales that use a different decimal separator.

### DIFF
--- a/src/main/java/com/gtnewhorizons/modularui/common/widget/textfield/BaseTextFieldWidget.java
+++ b/src/main/java/com/gtnewhorizons/modularui/common/widget/textfield/BaseTextFieldWidget.java
@@ -65,14 +65,15 @@ public class BaseTextFieldWidget extends Widget implements IWidgetParent, Intera
      * A mathematical expression. Supported:
      * <ul>
      * <li>digits: 0..9</li>
-     * <li>decimal point: .</li>
-     * <li>thousands separators: , _ [space]</li>
+     * <li>decimal point: , or . (interpreted based on locale)</li>
+     * <li>thousands separators: , . [space] (interpreted based on locale)</li>
      * <li>arithmetic operations: + - * / % ^</li>
-     * <li>decimal exponent: e E</li>
+     * <li>scientific notation: e E</li>
      * <li>decimal suffixes: k K m M b B g G t T</li>
+     * <li>spaces between tokens (ignored)</li>
      * </ul>
      */
-    public static final Pattern MATH_EXPRESSION = Pattern.compile("[0-9.,_ +\\-*/%^eEkKmMgGbBtT]*");
+    public static final Pattern MATH_EXPRESSION = Pattern.compile("[0-9., +\\-*/%^eEkKmMgGbBtT]*");
 
     /**
      * alphabets

--- a/src/main/java/com/gtnewhorizons/modularui/common/widget/textfield/TextFieldWidget.java
+++ b/src/main/java/com/gtnewhorizons/modularui/common/widget/textfield/TextFieldWidget.java
@@ -268,7 +268,7 @@ public class TextFieldWidget extends BaseTextFieldWidget implements ISyncedWidge
             if (val.isEmpty()) {
                 num = 0;
             } else {
-                num = (long) MathExpression.parseMathExpression(val);
+                num = (long) MathExpression.parseMathExpression(val, decimalFormat);
             }
             return decimalFormat.format(validator.apply(num));
         });
@@ -282,7 +282,7 @@ public class TextFieldWidget extends BaseTextFieldWidget implements ISyncedWidge
             if (val.isEmpty()) {
                 num = 0;
             } else {
-                num = (int) MathExpression.parseMathExpression(val);
+                num = (int) MathExpression.parseMathExpression(val, decimalFormat);
             }
             return decimalFormat.format(validator.apply(num));
         });
@@ -295,7 +295,7 @@ public class TextFieldWidget extends BaseTextFieldWidget implements ISyncedWidge
             if (val.isEmpty()) {
                 num = 0;
             } else {
-                num = MathExpression.parseMathExpression(val);
+                num = MathExpression.parseMathExpression(val, decimalFormat);
             }
             return decimalFormat.format(validator.apply(num));
         });
@@ -326,8 +326,8 @@ public class TextFieldWidget extends BaseTextFieldWidget implements ISyncedWidge
      */
     public TextFieldWidget setOnScrollNumbers(BiFunction<Integer, Integer, Integer> onScroll) {
         return setOnScroll(
-                (text, direction) -> decimalFormat
-                        .format(onScroll.apply((int) MathExpression.parseMathExpression(text), direction)));
+                (text, direction) -> decimalFormat.format(
+                        onScroll.apply((int) MathExpression.parseMathExpression(text, decimalFormat), direction)));
     }
 
     public TextFieldWidget setOnScrollNumbers(int baseStep, int ctrlStep, int shiftStep) {
@@ -349,7 +349,7 @@ public class TextFieldWidget extends BaseTextFieldWidget implements ISyncedWidge
     public TextFieldWidget setOnScrollNumbersDouble(BiFunction<Double, Integer, Double> onScroll) {
         return setOnScroll(
                 (text, direction) -> decimalFormat
-                        .format(onScroll.apply(MathExpression.parseMathExpression(text), direction)));
+                        .format(onScroll.apply(MathExpression.parseMathExpression(text, decimalFormat), direction)));
     }
 
     /**
@@ -357,8 +357,8 @@ public class TextFieldWidget extends BaseTextFieldWidget implements ISyncedWidge
      */
     public TextFieldWidget setOnScrollNumbersLong(BiFunction<Long, Integer, Long> onScroll) {
         return setOnScroll(
-                (text, direction) -> decimalFormat
-                        .format(onScroll.apply((long) MathExpression.parseMathExpression(text), direction)));
+                (text, direction) -> decimalFormat.format(
+                        onScroll.apply((long) MathExpression.parseMathExpression(text, decimalFormat), direction)));
     }
 
     public TextFieldWidget setOnScrollNumbersLong(long baseStep, long ctrlStep, long shiftStep) {

--- a/src/main/java/com/gtnewhorizons/modularui/test/TestTile.java
+++ b/src/main/java/com/gtnewhorizons/modularui/test/TestTile.java
@@ -178,7 +178,7 @@ public class TestTile extends TileEntity implements ITileWithModularUI {
                     changeableWidget.notifyChangeServer();
                 }).setShiftClickPriority(0).setPos(10, 30))
                 .addChild(
-                        new TextFieldWidget().setGetter(() -> String.valueOf(longValue))
+                        new TextFieldWidget().setGetterLong(() -> longValue)
                                 .setSetter(val -> longValue = (long) MathExpression.parseMathExpression(val))
                                 .setNumbersLong(val -> val).setTextColor(Color.WHITE.dark(1))
                                 .setTextAlignment(Alignment.CenterLeft).setScrollBar()

--- a/src/test/java/com/gtnewhorizons/modularui/api/math/MathExpressionTest.java
+++ b/src/test/java/com/gtnewhorizons/modularui/api/math/MathExpressionTest.java
@@ -2,9 +2,16 @@ package com.gtnewhorizons.modularui.api.math;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.text.NumberFormat;
+import java.util.Locale;
+
 import org.junit.jupiter.api.Test;
 
 class MathExpressionTest {
+
+    static final NumberFormat formatEnglish = NumberFormat.getInstance(Locale.ENGLISH);
+    static final NumberFormat formatFrench = NumberFormat.getInstance(Locale.FRENCH);
+    static final NumberFormat formatSpanish = NumberFormat.getInstance(Locale.forLanguageTag("ES"));
 
     @Test
     void NumbersBasic_Test() {
@@ -12,10 +19,20 @@ class MathExpressionTest {
         assertEquals(42, MathExpression.parseMathExpression("  42  "));
 
         assertEquals(123456, MathExpression.parseMathExpression("123,456"));
-        assertEquals(123456, MathExpression.parseMathExpression("123 456"));
-        assertEquals(123456, MathExpression.parseMathExpression("123_456"));
+    }
 
-        assertEquals(123.456, MathExpression.parseMathExpression("123.456"));
+    @Test
+    void NumbersLocalization_Test() {
+        assertEquals(123456.789, MathExpression.parseMathExpression("123,456.789", formatEnglish));
+        assertEquals(123456.789, MathExpression.parseMathExpression("123.456,789", formatSpanish));
+
+        // Using spaces
+        assertEquals(123456.789, MathExpression.parseMathExpression("123 456,789", formatFrench));
+        // Using correct decimal separator (char 0xA0)
+        assertEquals(123456.789, MathExpression.parseMathExpression(formatFrench.format(123456.789), formatFrench));
+
+        // This shouldn't work in locales that do not use spaces as decimal separator, but we take it anyway.
+        assertEquals(123456, MathExpression.parseMathExpression("123 456", formatEnglish));
     }
 
     @Test
@@ -58,7 +75,7 @@ class MathExpressionTest {
         assertEquals(2000, MathExpression.parseMathExpression("2e3"));
         assertEquals(3000, MathExpression.parseMathExpression("3E3"));
         assertEquals(4000, MathExpression.parseMathExpression("4 e 3"));
-        assertEquals(5600, MathExpression.parseMathExpression("5.6e3"));
+        assertEquals(5600, MathExpression.parseMathExpression("5.6e3", formatEnglish));
         assertEquals(70_000, MathExpression.parseMathExpression("700e2"));
         assertEquals(8, MathExpression.parseMathExpression("8e0"));
     }
@@ -87,8 +104,8 @@ class MathExpressionTest {
         assertEquals(10_000_000_000_000D, MathExpression.parseMathExpression("10t"));
         assertEquals(11_000_000_000_000D, MathExpression.parseMathExpression("11T"));
 
-        assertEquals(2050, MathExpression.parseMathExpression("2.05k"));
-        assertEquals(50, MathExpression.parseMathExpression("0.05k"));
+        assertEquals(2050, MathExpression.parseMathExpression("2.05k", formatEnglish));
+        assertEquals(50, MathExpression.parseMathExpression("0.05k", formatEnglish));
         assertEquals(3000, MathExpression.parseMathExpression("3 k"));
     }
 
@@ -105,9 +122,9 @@ class MathExpressionTest {
 
         // Not supported, but shouldn't fail.
         assertEquals(6_000_000_000D, MathExpression.parseMathExpression("6km"));
-        assertEquals(500_000, MathExpression.parseMathExpression("0.5ke3"));
+        assertEquals(500_000, MathExpression.parseMathExpression("0.5ke3", formatEnglish));
 
         // Please don't do this.
-        assertEquals(20_000_000_000D, MathExpression.parseMathExpression("2e0.01k"));
+        assertEquals(20_000_000_000D, MathExpression.parseMathExpression("2e0.01k", formatEnglish));
     }
 }

--- a/src/test/java/com/gtnewhorizons/modularui/api/math/MathExpressionTest.java
+++ b/src/test/java/com/gtnewhorizons/modularui/api/math/MathExpressionTest.java
@@ -18,7 +18,7 @@ class MathExpressionTest {
         assertEquals(42, MathExpression.parseMathExpression("42"));
         assertEquals(42, MathExpression.parseMathExpression("  42  "));
 
-        assertEquals(123456, MathExpression.parseMathExpression("123,456"));
+        assertEquals(123456, MathExpression.parseMathExpression("123456"));
     }
 
     @Test


### PR DESCRIPTION
This is a correction to https://github.com/GTNewHorizons/ModularUI/pull/58.

Number parsing in `MathExpression.parseMathExpression()` will now try to use a `NumberFormat` given by the `TextFieldWidget` using it; or the system default `NumberFormat` if none has been provided (or if called from outside a `TextFieldWidget`).

This means that numbers are now correctly parsed in locales that use a different thousands and decimal separators than `,` and `.`. Hopefully this should fix tests failing for @Dream-Master .

However current code still uses a mix of locale-aware formatting, and `String.valueOf()`. Also, since the raw text of the widget is exposed to the user, there is no way to guarantee that whoever is using the widget follows locale settings correctly.

Specifically for *integer numbers*, right now, this does not matter; as `BaseTextFieldWidget` hides thousands separators; and so most common number formats will appear identical. But if anybody wants a widget that can show non-integer decimal numbers, or to show thousands separators (the latter of which I would like to do), this could cause problems.

(And just for clarity, this problem is not caused by either this PR or the previous one; it was present in the code before too. It was only not apparent because people didn't try to input decimal numbers into the text field.)

I can see at least two possible solutions:
* Stick our head into the sand and mandate the US (or some other) locale on everybody. (I am not necessarily implying that this is unreasonable.)
* Create a new type of widget, `NumericWidget`, which would only expose the numeric value to the user, and manage all input/parsing/display on its own. Then switch over any code that previously used a `TextWidget` to input numbers to the new numeric widget.