### PR TITLE
Added a numeric widget.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,7 +5,8 @@ dependencies {
 
     api("com.github.GTNewHorizons:NotEnoughItems:2.5.18-GTNH:dev")
 
-    compileOnly("com.github.GTNewHorizons:Hodgepodge:2.4.25:dev") { transitive = false }
+    implementation("com.github.GTNewHorizons:GTNHLib:0.2.6:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Hodgepodge:2.4.28:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.45.71:dev") {
         transitive = false
         exclude group:"com.github.GTNewHorizons", module:"ModularUI"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,15 +3,15 @@
 dependencies {
     api("org.jetbrains:annotations:23.0.0")
 
-    api("com.github.GTNewHorizons:NotEnoughItems:2.5.18-GTNH:dev")
+    api("com.github.GTNewHorizons:NotEnoughItems:2.5.19-GTNH:dev")
 
-    implementation("com.github.GTNewHorizons:GTNHLib:0.2.6:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Hodgepodge:2.4.28:dev") { transitive = false }
+    implementation("com.github.GTNewHorizons:GTNHLib:0.2.7:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Hodgepodge:2.4.29:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.45.71:dev") {
         transitive = false
         exclude group:"com.github.GTNewHorizons", module:"ModularUI"
     }
-    compileOnly("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-324-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-325-GTNH:dev") { transitive = false }
 
     testImplementation(platform('org.junit:junit-bom:5.9.2'))
     testImplementation('org.junit.jupiter:junit-jupiter')

--- a/src/main/java/com/gtnewhorizons/modularui/ModularUI.java
+++ b/src/main/java/com/gtnewhorizons/modularui/ModularUI.java
@@ -51,6 +51,7 @@ public class ModularUI {
     public static final boolean isGT5ULoaded = Loader.isModLoaded(MODID_GT5U) && !Loader.isModLoaded(MODID_GT6);
     public static final boolean isHodgepodgeLoaded = Loader.isModLoaded("hodgepodge");
     public static final boolean isAE2Loaded = Loader.isModLoaded("appliedenergistics2");
+    public static final boolean isGTNHLibLoaded = Loader.isModLoaded("gtnhlib");
 
     public static final boolean isDevEnv = (boolean) Launch.blackboard.get("fml.deobfuscatedEnvironment");
 

--- a/src/main/java/com/gtnewhorizons/modularui/ModularUI.java
+++ b/src/main/java/com/gtnewhorizons/modularui/ModularUI.java
@@ -41,6 +41,7 @@ public class ModularUI {
     public static final String DEPENDENCIES = "required-after:gtnhmixins@[2.0.1,); "
             + "required-after:NotEnoughItems@[2.3.50-GTNH,);"
             + "after:hodgepodge@[2.0.0,);"
+            + "after:gtnhlib@[0.2.7,);"
             + "before:gregtech";
     public static final String GUI_FACTORY = "com.gtnewhorizons.modularui.config.GuiFactory";
 

--- a/src/main/java/com/gtnewhorizons/modularui/common/widget/textfield/NumericWidget.java
+++ b/src/main/java/com/gtnewhorizons/modularui/common/widget/textfield/NumericWidget.java
@@ -1,0 +1,385 @@
+package com.gtnewhorizons.modularui.common.widget.textfield;
+
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Locale;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+
+import net.minecraft.network.PacketBuffer;
+
+import com.gtnewhorizon.gtnhlib.util.parsing.MathExpressionParser;
+import com.gtnewhorizon.gtnhlib.util.parsing.MathExpressionParser.Context;
+import com.gtnewhorizons.modularui.ModularUI;
+import com.gtnewhorizons.modularui.api.math.Alignment;
+import com.gtnewhorizons.modularui.api.widget.ISyncedWidget;
+import com.gtnewhorizons.modularui.api.widget.Interactable;
+
+/**
+ * A widget that allows the user to enter a numeric value. Synced between client and server. Automatically handles
+ * number parsing and formatting. Only the numeric value (of type <code>double</code>) is exposed to the calling code.
+ * <p>
+ * If GTNHLib is present, also allows entering values as mathematical expressions.
+ */
+public class NumericWidget extends BaseTextFieldWidget implements ISyncedWidget {
+
+    private double value = 0;
+    private Supplier<Double> getter;
+    private Consumer<Double> setter;
+    private Function<Double, Double> validator;
+
+    private double minValue = 0;
+    private double maxValue = Double.POSITIVE_INFINITY;
+    private double defaultValue = 0;
+    private double scrollStep = 1;
+    private double scrollStepCtrl = 0.1;
+    private double scrollStepShift = 100;
+    private boolean integerOnly = true;
+    private Context ctx;
+    private NumberFormat numberFormat;
+    private static final Pattern NUMBER_PATTERN = Pattern.compile("-?[0-9.,  _]*");
+
+    public NumericWidget() {
+        setTextAlignment(Alignment.CenterLeft);
+        handler.setMaxLines(1);
+
+        // TODO: handle localization into the player's system locale.
+        // This needs to be configurable in the config, if a player wants to force the US (or any other) locale despite
+        // their system settings.
+        numberFormat = DecimalFormat.getNumberInstance(Locale.US);
+
+        // If you need more than 4 decimal digits of precision, use getNumberFormat().setMaximumFractionDigits().
+        numberFormat.setMaximumFractionDigits(4);
+
+        if (ModularUI.isGTNHLibLoaded) {
+            handler.setPattern(MathExpressionParser.EXPRESSION_PATTERN);
+            ctx = new MathExpressionParser.Context();
+            ctx.setNumberFormat(numberFormat);
+        } else {
+            handler.setPattern(NUMBER_PATTERN);
+        }
+    }
+
+    public double getValue() {
+        return value;
+    }
+
+    public void setValue(double newValue) {
+        value = newValue;
+        if (handler.getText().isEmpty()) {
+            handler.getText().add(numberFormat.format(value));
+        } else {
+            handler.getText().set(0, numberFormat.format(value));
+        }
+    }
+
+    /**
+     * @return true if the value has changed.
+     */
+    private boolean validateAndSetValue(double newValue) {
+        newValue = Math.max(newValue, minValue);
+        newValue = Math.min(newValue, maxValue);
+        if (integerOnly) {
+            newValue = Math.round(newValue);
+        }
+        if (validator != null) {
+            newValue = validator.apply(newValue);
+        }
+
+        // We want to call setValue even if the value has not changed.
+        // The text field might contain an expression which evaluates to the old value,
+        // we still want to replace this expression with an actual number.
+        boolean changed = newValue != value;
+        setValue(newValue);
+        return changed;
+    }
+
+    private double parseValueFromTextField() {
+        if (handler.getText().isEmpty()) {
+            handler.getText().add("");
+        }
+        if (handler.getText().size() > 1) {
+            throw new IllegalStateException("NumericWidget can only have one line!");
+        }
+
+        if (ModularUI.isGTNHLibLoaded) {
+            double newValue = MathExpressionParser.parse(handler.getText().get(0), ctx);
+            return ctx.wasSuccessful() ? newValue : value;
+        } else {
+            if (handler.getText().get(0) == null || handler.getText().get(0).isEmpty()) {
+                return defaultValue;
+            }
+            try {
+                return numberFormat.parse(handler.getText().get(0)).doubleValue();
+            } catch (ParseException ignore) {
+                return value;
+            }
+        }
+    }
+
+    /* Configure widget properties. */
+
+    /**
+     * Sets the minimum allowed input value. Can be negative.
+     * <p>
+     * Default: 0
+     */
+    public NumericWidget setMinValue(double minValue) {
+        this.minValue = minValue;
+        return this;
+    }
+
+    /**
+     * Sets the maximum allowed input value. This is also used to evaluate expressions that refer to a percentage of the
+     * maximum.
+     * <p>
+     * Default: Double.POSITIVE_INFINITY.
+     */
+    public NumericWidget setMaxValue(double maxValue) {
+        this.maxValue = maxValue;
+        if (ModularUI.isGTNHLibLoaded) {
+            ctx.setHundredPercent(maxValue);
+        }
+        return this;
+    }
+
+    /**
+     * Sets the default input value to be used when the text field is empty.
+     * <p>
+     * Default: 0.
+     */
+    public NumericWidget setDefaultValue(double defaultValue) {
+        this.defaultValue = defaultValue;
+        if (ModularUI.isGTNHLibLoaded) {
+            ctx.setDefaultValue(defaultValue);
+        }
+        return this;
+    }
+
+    /**
+     * Sets the values by which to increment the value when the player uses the scroll wheel. Scrolling up increases the
+     * value, scrolling down decreases. The typical convention is for ctrl to be a smaller step than the base, and shift
+     * to be a larger step; but this can be changed if there is a good reason.
+     * <p>
+     * Default values: 1, 0.1, 100 in order.
+     *
+     * @param baseStep  By how much to change the value when no modifier key is held.
+     * @param ctrlStep  By how much to change the value when the ctrl key is held.
+     * @param shiftStep By how much to change the value when the shift key is held.
+     */
+    public NumericWidget setScrollValues(double baseStep, double ctrlStep, double shiftStep) {
+        this.scrollStep = baseStep;
+        this.scrollStepCtrl = ctrlStep;
+        this.scrollStepShift = shiftStep;
+        return this;
+    }
+
+    /**
+     * If this is set to true, the widget will always round the entered value to the nearest integer. Otherwise, the
+     * value is returned with full precision.
+     * <p>
+     * Default: true.
+     */
+    public NumericWidget setIntegerOnly(boolean integerOnly) {
+        this.integerOnly = integerOnly;
+        return this;
+    }
+
+    /**
+     * If this is set to true, the widget will only accept a single number, and will not try to evaluate mathematical
+     * expressions. Note that expression parsing requires GTNHLib.
+     * <p>
+     * Default: false.
+     */
+    public NumericWidget setPlainOnly(boolean plainOnly) {
+        if (ModularUI.isGTNHLibLoaded) {
+            ctx.setPlainOnly(plainOnly);
+            handler.setPattern(plainOnly ? NUMBER_PATTERN : MathExpressionParser.EXPRESSION_PATTERN);
+        }
+        return this;
+    }
+
+    /**
+     * Returns the {@link NumberFormat} used by this widget. This is a more direct method of modifying this format, such
+     * as number of decimal spaces, than calling {@link #setNumberFormat(NumberFormat)} with a completely new format.
+     */
+    public NumberFormat getNumberFormat() {
+        return numberFormat;
+    }
+
+    /**
+     * Sets a {@link NumberFormat} to be used for formatting the value in the input field. Modifying the formatter
+     * returned from {@link #getNumberFormat()} should be sufficient in most cases, call this only when you need to use
+     * a completely different formatter.
+     */
+    public NumericWidget setNumberFormat(NumberFormat numberFormat) {
+        this.numberFormat = numberFormat;
+        if (ModularUI.isGTNHLibLoaded) {
+            ctx.setNumberFormat(numberFormat);
+        }
+        return this;
+    }
+
+    /**
+     * Sets a supplier of numeric values to display in the input field.
+     */
+    public NumericWidget setGetter(Supplier<Double> getter) {
+        this.getter = getter;
+        return this;
+    }
+
+    /**
+     * Sets a consumer of values entered by the player.
+     */
+    public NumericWidget setSetter(Consumer<Double> setter) {
+        this.setter = setter;
+        return this;
+    }
+
+    /**
+     * Sets a validator for entered values. For simply restricting the value to a certain range, use
+     * {@link #setMinValue(double)} and {@link #setMaxValue(double)}.
+     */
+    public NumericWidget setValidator(Function<Double, Double> validator) {
+        this.validator = validator;
+        return this;
+    }
+
+    /* Event handlers. */
+
+    @Override
+    public void onRemoveFocus() {
+        super.onRemoveFocus();
+
+        double newValue = parseValueFromTextField();
+        if (validateAndSetValue(newValue)) {
+            if (setter != null) {
+                setter.accept(value);
+            }
+            if (syncsToServer()) {
+                syncToServer(1, buffer -> buffer.writeDouble(value));
+            }
+        }
+    }
+
+    @Override
+    public boolean onMouseScroll(int direction) {
+        if (!isFocused()) return false;
+
+        double newValue = parseValueFromTextField();
+
+        if (Interactable.hasControlDown()) newValue += direction * scrollStepCtrl;
+        else if (Interactable.hasShiftDown()) newValue += direction * scrollStepShift;
+        else newValue += direction * scrollStep;
+
+        if (validateAndSetValue(newValue)) {
+            if (setter != null) {
+                setter.accept(value);
+            }
+            if (syncsToServer()) {
+                syncToServer(1, buffer -> buffer.writeDouble(value));
+            }
+        }
+        return true;
+    }
+
+    /* ISyncedWidget implementation. */
+
+    private boolean needsUpdate;
+    private boolean syncsToServer = true;
+    private boolean syncsToClient = true;
+
+    /**
+     * @return if this widget should operate on the server side. For example detecting and sending changes to client.
+     */
+    public boolean syncsToClient() {
+        return syncsToClient;
+    }
+
+    /**
+     * @return if this widget should operate on the client side. For example, sending a changed value to the server.
+     */
+    public boolean syncsToServer() {
+        return syncsToServer;
+    }
+
+    /**
+     * Determines how this widget should sync values
+     *
+     * @param syncsToClient if this widget should sync changes to the server
+     * @param syncsToServer if this widget should detect changes on server and sync them to client
+     */
+    public NumericWidget setSynced(boolean syncsToClient, boolean syncsToServer) {
+        this.syncsToClient = syncsToClient;
+        this.syncsToServer = syncsToServer;
+        return this;
+    }
+
+    @Override
+    public void detectAndSendChanges(boolean init) {
+        if (syncsToClient() && getter != null) {
+            double newValue = getter.get();
+
+            // Order matters here, validateAndSetValue() has side effects, it needs to be evaluated first so that it
+            // does not get short-circuited.
+            if (validateAndSetValue(newValue) || init) {
+                syncToClient(1, buffer -> {
+                    buffer.writeBoolean(init);
+                    buffer.writeDouble(value);
+                });
+                markForUpdate();
+            }
+        }
+    }
+
+    @Override
+    public void readOnClient(int id, PacketBuffer buf) {
+        if (id == 1) {
+            boolean init = buf.readBoolean();
+            if (init || !isFocused()) {
+                validateAndSetValue(buf.readDouble());
+                if (init) {
+                    lastText = new ArrayList<>(handler.getText());
+                    if (focusOnGuiOpen) {
+                        forceFocus();
+                    }
+                }
+                if (this.setter != null && (this.getter == null || this.getter.get() != value)) {
+                    this.setter.accept(value);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void readOnServer(int id, PacketBuffer buf) {
+        if (id == 1) {
+            if (validateAndSetValue(buf.readDouble())) {
+                if (this.setter != null) {
+                    this.setter.accept(value);
+                }
+                markForUpdate();
+            }
+        }
+    }
+
+    @Override
+    public void markForUpdate() {
+        needsUpdate = true;
+    }
+
+    @Override
+    public void unMarkForUpdate() {
+        needsUpdate = false;
+    }
+
+    @Override
+    public boolean isMarkedForUpdate() {
+        return needsUpdate;
+    }
+
+}

--- a/src/main/java/com/gtnewhorizons/modularui/common/widget/textfield/NumericWidget.java
+++ b/src/main/java/com/gtnewhorizons/modularui/common/widget/textfield/NumericWidget.java
@@ -47,7 +47,7 @@ public class NumericWidget extends BaseTextFieldWidget implements ISyncedWidget 
     private static final int MAX_FRACTION_DIGITS = 4;
     private static final Pattern NUMBER_PATTERN = Pattern.compile("-?[0-9., \u202F_’]*");
     // Character '\u202F' (non-breaking space) to support French locale thousands separator.
-    private boolean shouldReplaceSpaces = false;
+    private final boolean shouldReplaceSpaces;
 
     public NumericWidget() {
         setTextAlignment(Alignment.CenterLeft);

--- a/src/main/java/com/gtnewhorizons/modularui/config/Config.java
+++ b/src/main/java/com/gtnewhorizons/modularui/config/Config.java
@@ -1,8 +1,10 @@
 package com.gtnewhorizons.modularui.config;
 
 import java.io.File;
+import java.util.Locale;
 
 import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.common.config.Property;
 
 import com.gtnewhorizons.modularui.ModularUI;
 
@@ -22,6 +24,8 @@ public class Config {
     public static boolean escRestoreLastText = false;
     public static boolean closeWindowsAtOnce = false;
 
+    public static Locale locale = Locale.getDefault();
+
     public static boolean useJson = false;
 
     public static boolean debug = false;
@@ -30,13 +34,14 @@ public class Config {
     public static final String CATEGORY_ANIMATIONS = "animations";
     public static final String CATEGORY_RENDERING = "rendering";
     public static final String CATEGORY_KEYBOARD = "keyboard";
+    public static final String CATEGORY_LOCALIZATION = "localization";
     public static final String CATEGORY_JSON = "json";
     public static final String CATEGORY_DEBUG = "debug";
 
     private static final String LANG_PREFIX = ModularUI.MODID + ".config.";
 
     public static final String[] CATEGORIES = new String[] { CATEGORY_ANIMATIONS, CATEGORY_RENDERING, CATEGORY_KEYBOARD,
-            CATEGORY_JSON, CATEGORY_DEBUG, };
+            CATEGORY_LOCALIZATION, CATEGORY_JSON, CATEGORY_DEBUG, };
 
     public static void init(File configFile) {
         config = new Configuration(configFile);
@@ -50,6 +55,8 @@ public class Config {
         config.setCategoryLanguageKey(CATEGORY_RENDERING, LANG_PREFIX + CATEGORY_RENDERING);
         config.setCategoryComment(CATEGORY_KEYBOARD, "Keyboard");
         config.setCategoryLanguageKey(CATEGORY_KEYBOARD, LANG_PREFIX + CATEGORY_KEYBOARD);
+        config.setCategoryComment(CATEGORY_LOCALIZATION, "Localization");
+        config.setCategoryLanguageKey(CATEGORY_LOCALIZATION, LANG_PREFIX + CATEGORY_LOCALIZATION);
         config.setCategoryComment(CATEGORY_JSON, "Json");
         config.setCategoryLanguageKey(CATEGORY_JSON, LANG_PREFIX + CATEGORY_JSON);
         config.setCategoryComment(CATEGORY_DEBUG, "Debug");
@@ -124,6 +131,29 @@ public class Config {
         closeWindowsAtOnce = config
                 .get(CATEGORY_KEYBOARD, "closeWindowsAtOnce", false, "Whether to close all the opened windows at once")
                 .setLanguageKey(LANG_PREFIX + CATEGORY_KEYBOARD + ".closeWindowsAtOnce").getBoolean();
+
+        // === Localization ===
+
+        Property property = config.get(
+                CATEGORY_LOCALIZATION,
+                "locale",
+                Locale.getDefault().toLanguageTag(),
+                "Locale to use to display GUI elements. Primarily used to display numbers in your regional format.")
+                .setLanguageKey(LANG_PREFIX + CATEGORY_LOCALIZATION + ".locale");
+
+        Locale newLocale = Locale.forLanguageTag(property.getString());
+        boolean isValid = false;
+        for (Locale l : Locale.getAvailableLocales()) {
+            if (l.equals(newLocale)) {
+                locale = newLocale;
+                isValid = true;
+                break;
+            }
+        }
+        if (!isValid) {
+            // Reset the config value.
+            property.set(locale.toLanguageTag());
+        }
 
         // === Json ===
 

--- a/src/main/java/com/gtnewhorizons/modularui/test/TestTile.java
+++ b/src/main/java/com/gtnewhorizons/modularui/test/TestTile.java
@@ -183,8 +183,8 @@ public class TestTile extends TileEntity implements ITileWithModularUI {
                                 .setMaxValue(999_000_000)//
                                 .setDefaultValue(50)//
                                 .setGetter(() -> (double) longValue)//
-                                .setSetter(val -> longValue = val.longValue())//
-                                // .setValidator(val -> Math.round(val / 2) * 2d)//
+                                .setSetter(val -> longValue = (long) val)//
+                                .setValidator(val -> Math.round(val / 2) * 2d)//
                                 .setScrollValues(2, 10, 1000)//
                                 .setTextColor(Color.WHITE.dark(1)).setBackground(DISPLAY.withOffset(-2, -2, 4, 4))
                                 .setSize(92, 20).setPos(10, 50))

--- a/src/main/java/com/gtnewhorizons/modularui/test/TestTile.java
+++ b/src/main/java/com/gtnewhorizons/modularui/test/TestTile.java
@@ -31,7 +31,6 @@ import com.gtnewhorizons.modularui.api.math.Alignment;
 import com.gtnewhorizons.modularui.api.math.Color;
 import com.gtnewhorizons.modularui.api.math.CrossAxisAlignment;
 import com.gtnewhorizons.modularui.api.math.MainAxisAlignment;
-import com.gtnewhorizons.modularui.api.math.MathExpression;
 import com.gtnewhorizons.modularui.api.math.Pos2d;
 import com.gtnewhorizons.modularui.api.math.Size;
 import com.gtnewhorizons.modularui.api.screen.ITileWithModularUI;
@@ -59,6 +58,7 @@ import com.gtnewhorizons.modularui.common.widget.TabButton;
 import com.gtnewhorizons.modularui.common.widget.TabContainer;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
 import com.gtnewhorizons.modularui.common.widget.VanillaButtonWidget;
+import com.gtnewhorizons.modularui.common.widget.textfield.NumericWidget;
 import com.gtnewhorizons.modularui.common.widget.textfield.TextFieldWidget;
 
 public class TestTile extends TileEntity implements ITileWithModularUI {
@@ -79,7 +79,8 @@ public class TestTile extends TileEntity implements ITileWithModularUI {
     private int progress = 0;
     private int ticks = 0;
     private float sliderValue = 0;
-    private long longValue = 0;
+    private long longValue = 50;
+    private double doubleValue;
     private int serverCounter = 0;
     private static final AdaptableUITexture DISPLAY = AdaptableUITexture
             .of("modularui:gui/background/display", 143, 75, 2);
@@ -176,13 +177,27 @@ public class TestTile extends TileEntity implements ITileWithModularUI {
                 .addChild(new SlotWidget(phantomInventory, 0).setChangeListener(() -> {
                     serverCounter = 0;
                     changeableWidget.notifyChangeServer();
-                }).setShiftClickPriority(0).setPos(10, 30))
+                }).setShiftClickPriority(0).setPos(10, 30)).addChild(
+                        new NumericWidget()//
+                                .setMinValue(-1_000_000)//
+                                .setMaxValue(5_000_000)//
+                                .setDefaultValue(50)//
+                                .setGetter(() -> (double) longValue)//
+                                .setSetter(val -> longValue = val.longValue())//
+                                // .setValidator(val -> Math.round(val / 2) * 2d)//
+                                .setScrollValues(2, 10, 1000)//
+                                .setTextColor(Color.WHITE.dark(1)).setBackground(DISPLAY.withOffset(-2, -2, 4, 4))
+                                .setSize(92, 20).setPos(10, 50))
                 .addChild(
-                        new TextFieldWidget().setGetter(() -> String.valueOf(longValue))
-                                .setSetter(val -> longValue = (long) MathExpression.parseMathExpression(val))
-                                .setNumbersLong(val -> val).setTextColor(Color.WHITE.dark(1))
-                                .setTextAlignment(Alignment.CenterLeft).setScrollBar()
-                                .setBackground(DISPLAY.withOffset(-2, -2, 4, 4)).setSize(92, 20).setPos(10, 50))
+                        new NumericWidget()//
+                                .setIntegerOnly(false)//
+                                .setMinValue(-1_000_000)//
+                                .setMaxValue(5_000_000)//
+                                .setDefaultValue(50)//
+                                .setGetter(() -> doubleValue)//
+                                .setSetter(val -> doubleValue = val)//
+                                .setTextColor(Color.WHITE.dark(1)).setBackground(DISPLAY.withOffset(-2, -2, 4, 4))
+                                .setSize(92, 20).setPos(100, 50))
                 .addChild(
                         SlotWidget.phantom(phantomInventory, 1).setShiftClickPriority(1).setIgnoreStackSizeLimit(true)
                                 .setControlsAmount(true).setPos(28, 30))

--- a/src/main/java/com/gtnewhorizons/modularui/test/TestTile.java
+++ b/src/main/java/com/gtnewhorizons/modularui/test/TestTile.java
@@ -79,8 +79,8 @@ public class TestTile extends TileEntity implements ITileWithModularUI {
     private int progress = 0;
     private int ticks = 0;
     private float sliderValue = 0;
-    private long longValue = 50;
-    private double doubleValue;
+    private long longValue = 123456789;
+    private double doubleValue = 123456.789;
     private int serverCounter = 0;
     private static final AdaptableUITexture DISPLAY = AdaptableUITexture
             .of("modularui:gui/background/display", 143, 75, 2);
@@ -180,7 +180,7 @@ public class TestTile extends TileEntity implements ITileWithModularUI {
                 }).setShiftClickPriority(0).setPos(10, 30)).addChild(
                         new NumericWidget()//
                                 .setMinValue(-1_000_000)//
-                                .setMaxValue(5_000_000)//
+                                .setMaxValue(999_000_000)//
                                 .setDefaultValue(50)//
                                 .setGetter(() -> (double) longValue)//
                                 .setSetter(val -> longValue = val.longValue())//
@@ -192,7 +192,7 @@ public class TestTile extends TileEntity implements ITileWithModularUI {
                         new NumericWidget()//
                                 .setIntegerOnly(false)//
                                 .setMinValue(-1_000_000)//
-                                .setMaxValue(5_000_000)//
+                                .setMaxValue(999_000_000)//
                                 .setDefaultValue(50)//
                                 .setGetter(() -> doubleValue)//
                                 .setSetter(val -> doubleValue = val)//

--- a/src/main/resources/assets/modularui/lang/en_US.lang
+++ b/src/main/resources/assets/modularui/lang/en_US.lang
@@ -26,6 +26,7 @@ modularui.fluid.click_to_empty=§7Left Click with a Fluid Container to empty the
 modularui.config.animations=Animations
 modularui.config.rendering=Rendering
 modularui.config.keyboard=Keyboard
+modularui.config.localization=Localization
 modularui.config.json=Json
 modularui.config.debug=Debug
 
@@ -47,6 +48,8 @@ modularui.config.keyboard.escRestoreLastText=Restore last text with esc key
 modularui.config.keyboard.escRestoreLastText.tooltip=Whether to restore last text if esc key is pressed in the text field
 modularui.config.keyboard.closeWindowsAtOnce=Close windows at once
 modularui.config.keyboard.closeWindowsAtOnce.tooltip=Whether to close all the opened windows at once
+modularui.config.localization.locale=Locale
+modularui.config.localization.locale.tooltip=Locale to use to display GUI elements. Primarily used to display numbers in your regional format.
 modularui.config.json.useJson=Use Json
 modularui.config.json.useJson.tooltip=Whether to enable Json. Enabling this will increase loading time.
 modularui.config.debug.debug=Enable debug


### PR DESCRIPTION
This adds a new widget, which to the player acts like a text field, but it is specialized for entering numeric values.

Code using this widget has access only to the number entered by the player, and does not need to (and can not) access the string representation that is visible in the UI. The widget handles all synchronization, parsing, and displaying the number appropriately.

Supported features:
* Text can be entered as a mathematical expression (see https://github.com/GTNewHorizons/GTNHLib/pull/31 and https://github.com/GTNewHorizons/ModularUI/pull/60)
* Parsing can be optionally disabled, if one wants only a very simple UI (for example, to select slot number in a chest?)
* Bounds checking (minimum/maximum).
* An option to allow only integer values (default), or arbitrary `double` numbers.
* Configurable number format. (Even the default one supports thousands separators and is much easier to read than the current implementation.)
* Scroll wheel support with configurable step sizes.
* Server/client synchronization. (Only the actual value is synchronized, so different clients can enter/display the numbers in different formats.)

Any features which are not directly related to entering and displaying numbers mirror the existing `TextFieldWidget` as closely as possible, for easy migration.

Showcasing just a few of the new features using the dummy TestTile:

https://github.com/GTNewHorizons/ModularUI/assets/19243993/90579dc7-068b-4211-ae5b-57c27e1279cf

Right now the mod has an added `implementation` dependency on GTNHLib. There is already code to detect whether GTNHLib is loaded, and replace expression parsing by just simple number parsing if it is not. However, after a discussion on discord, it seems that if I set the GTNHLib dependency as `compileOnly`, then Hodgepodge is incorrectly pulling in an outdated version of GTNHLib (0.2.3) which does not have the expression parsing support. If this problem is fixed, then the hard dependency on GTNHLib can be removed for non-GTNH packs.

Previously I have talked about support for localization of number input and parsing for different locales; the background systems and synchronization is ready for it, but the actual selection of the correct locale has not been implemented yet. Ideally I would like to add this before this PR is done.

After this PR is merged, every `TextFieldWidget` anywhere in the pack which is used only to input a numeric value can be replaced by `NumericWidget` to take advantage of the new features, and functions of `TextFieldWidget` which deal with numeric input should be deprecated/removed.

Any comments/feedback/suggestions are welcome.