### PR TITLE
Added a text supplier for TextWidget.

### DIFF
--- a/src/main/java/com/gtnewhorizons/modularui/common/widget/TextWidget.java
+++ b/src/main/java/com/gtnewhorizons/modularui/common/widget/TextWidget.java
@@ -106,12 +106,20 @@ public class TextWidget extends Widget {
         return text;
     }
 
+    /**
+     * The textSupplier will ONLY be called on the client. It must have access to all the data it needs to build the
+     * text from the client side.
+     */
     public TextWidget setTextSupplier(Supplier<Text> textSupplier) {
         this.textSupplier = textSupplier;
         this.isDynamic = textSupplier != null;
         return this;
     }
 
+    /**
+     * The stringSupplier will ONLY be called on the client. It must have access to all the data it needs to build the
+     * text from the client side.
+     */
     public TextWidget setStringSupplier(Supplier<String> stringSupplier) {
         if (stringSupplier != null) {
             this.textSupplier = () -> new Text(stringSupplier.get());

--- a/src/main/java/com/gtnewhorizons/modularui/common/widget/TextWidget.java
+++ b/src/main/java/com/gtnewhorizons/modularui/common/widget/TextWidget.java
@@ -19,8 +19,9 @@ import com.gtnewhorizons.modularui.common.internal.Theme;
  */
 public class TextWidget extends Widget {
 
-    private final Text text;
+    private Text text;
     protected String localised;
+    protected Supplier<Text> textSupplier = null;
     private int maxWidth = -1;
     private Alignment textAlignment = Alignment.Center;
     private final TextRenderer textRenderer = new TextRenderer();
@@ -76,6 +77,9 @@ public class TextWidget extends Widget {
 
     @Override
     public void onScreenUpdate() {
+        if (textSupplier != null) {
+            text = textSupplier.get();
+        }
         if (isDynamic || isAutoSized()) {
             String l = getText().getFormatted();
             if (!l.equals(localised)) {
@@ -100,6 +104,22 @@ public class TextWidget extends Widget {
 
     public Text getText() {
         return text;
+    }
+
+    public TextWidget setTextSupplier(Supplier<Text> textSupplier) {
+        this.textSupplier = textSupplier;
+        this.isDynamic = textSupplier != null;
+        return this;
+    }
+
+    public TextWidget setStringSupplier(Supplier<String> stringSupplier) {
+        if (stringSupplier != null) {
+            this.textSupplier = () -> new Text(stringSupplier.get());
+            this.isDynamic = true;
+        } else {
+            this.isDynamic = false;
+        }
+        return this;
     }
 
     public TextWidget setDefaultColor(int color) {

--- a/src/main/java/com/gtnewhorizons/modularui/test/TestTile.java
+++ b/src/main/java/com/gtnewhorizons/modularui/test/TestTile.java
@@ -5,17 +5,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import com.gtnewhorizons.modularui.common.widget.DynamicTextWidget;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EnumChatFormatting;
-import net.minecraft.util.StatCollector;
-import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidTank;
 
 import org.jetbrains.annotations.NotNull;
@@ -24,7 +20,6 @@ import com.gtnewhorizons.modularui.ModularUI;
 import com.gtnewhorizons.modularui.api.ModularUITextures;
 import com.gtnewhorizons.modularui.api.NumberFormatMUI;
 import com.gtnewhorizons.modularui.api.drawable.AdaptableUITexture;
-import com.gtnewhorizons.modularui.api.drawable.FluidDrawable;
 import com.gtnewhorizons.modularui.api.drawable.ItemDrawable;
 import com.gtnewhorizons.modularui.api.drawable.Text;
 import com.gtnewhorizons.modularui.api.drawable.UITexture;
@@ -45,7 +40,7 @@ import com.gtnewhorizons.modularui.common.widget.ChangeableWidget;
 import com.gtnewhorizons.modularui.common.widget.Column;
 import com.gtnewhorizons.modularui.common.widget.CycleButtonWidget;
 import com.gtnewhorizons.modularui.common.widget.DrawableWidget;
-import com.gtnewhorizons.modularui.common.widget.DropDownWidget;
+import com.gtnewhorizons.modularui.common.widget.DynamicTextWidget;
 import com.gtnewhorizons.modularui.common.widget.ExpandTab;
 import com.gtnewhorizons.modularui.common.widget.FluidSlotWidget;
 import com.gtnewhorizons.modularui.common.widget.MultiChildWidget;
@@ -59,7 +54,6 @@ import com.gtnewhorizons.modularui.common.widget.SortableListWidget;
 import com.gtnewhorizons.modularui.common.widget.TabButton;
 import com.gtnewhorizons.modularui.common.widget.TabContainer;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
-import com.gtnewhorizons.modularui.common.widget.VanillaButtonWidget;
 import com.gtnewhorizons.modularui.common.widget.textfield.NumericWidget;
 import com.gtnewhorizons.modularui.common.widget.textfield.TextFieldWidget;
 
@@ -179,7 +173,7 @@ public class TestTile extends TileEntity implements ITileWithModularUI {
         return new MultiChildWidget().addChild(new TextWidget("Page 1"))
                 .addChild(new SlotWidget(phantomInventory, 0).setChangeListener(() -> {
                     serverCounter = 0;
-                    //changeableWidget.notifyChangeServer();
+                    // changeableWidget.notifyChangeServer();
                 }).setShiftClickPriority(0).setPos(10, 30)).addChild(
                         new NumericWidget()//
                                 .setMinValue(-1_000_000)//
@@ -201,44 +195,36 @@ public class TestTile extends TileEntity implements ITileWithModularUI {
                                 .setSetter(val -> doubleValue = val)//
                                 .setTextColor(Color.WHITE.dark(1)).setBackground(DISPLAY.withOffset(-2, -2, 4, 4))
                                 .setSize(92, 20).setPos(100, 50))
-                .addChild(new TextWidget("TextWidget:\n" + numberFormat.format(System.currentTimeMillis()))
-                    .setTextAlignment(Alignment.CenterLeft).setPos(10, 80))
-                .addChild(new DynamicTextWidget(() -> new Text("DynamicTextWidget:\n" + numberFormat.format(System.currentTimeMillis())))
-                    .setTextAlignment(Alignment.CenterLeft).setPos(10, 100))
-                .addChild(new TextWidget().setStringSupplier(() -> "w/ Supplier:\n" + numberFormat.format(System.currentTimeMillis()))
-                    .setTextAlignment(Alignment.CenterLeft).setPos(10, 120))
+                .addChild(
+                        new TextWidget("TextWidget:\n" + numberFormat.format(System.currentTimeMillis()))
+                                .setTextAlignment(Alignment.CenterLeft).setPos(10, 80))
+                .addChild(
+                        new DynamicTextWidget(
+                                () -> new Text(
+                                        "DynamicTextWidget:\n" + numberFormat.format(System.currentTimeMillis())))
+                                                .setTextAlignment(Alignment.CenterLeft).setPos(10, 100))
+                .addChild(
+                        new TextWidget()
+                                .setStringSupplier(
+                                        () -> "w/ Supplier:\n" + numberFormat.format(System.currentTimeMillis()))
+                                .setTextAlignment(Alignment.CenterLeft).setPos(10, 120))
 
-                /*.addChild(
-                        SlotWidget.phantom(phantomInventory, 1).setShiftClickPriority(1).setIgnoreStackSizeLimit(true)
-                                .setControlsAmount(true).setPos(28, 30))
-                .addChild(changeableWidget.setPos(12, 55))
-                .addChild(SlotGroup.ofItemHandler(items, 3).build().setPos(12, 80))
-                .addChild(
-                        new DropDownWidget().addDropDownItemsSimple(
-                                IntStream.range(0, 20).boxed().map(i -> "label " + i).collect(Collectors.toList()),
-                                (buttonWidget, index, label, setSelected) -> buttonWidget
-                                        .setOnClick((clickData, widget) -> {
-                                            if (!widget.isClient()) {
-                                                widget.getContext().getPlayer()
-                                                        .addChatMessage(new ChatComponentText("Selected " + label));
-                                            }
-                                            setSelected.run();
-                                        }),
-                                true).setExpandedMaxHeight(60).setDirection(DropDownWidget.Direction.DOWN)
-                                .setPos(90, 30).setSize(60, 11))
-                .addChild(
-                        new VanillaButtonWidget()
-                                .setDisplayString(StatCollector.translateToLocal("modularui.config.debug"))
-                                .setOnClick((clickData, widget) -> {
-                                    if (!widget.isClient()) {
-                                        widget.getContext().getPlayer().addChatMessage(
-                                                new ChatComponentText(numberFormat.formatWithSuffix(longValue)));
-                                    }
-                                }).setPos(70, 80).setSize(32, 16).setInternalName("debug"))
-                .addChild(
-                        new DrawableWidget()
-                                .setDrawable(new FluidDrawable().setFluid(FluidRegistry.LAVA).withFixedSize(32, 16))
-                                .setPos(70, 100).setSize(32, 16))*/
+                /*
+                 * .addChild( SlotWidget.phantom(phantomInventory,
+                 * 1).setShiftClickPriority(1).setIgnoreStackSizeLimit(true) .setControlsAmount(true).setPos(28, 30))
+                 * .addChild(changeableWidget.setPos(12, 55)) .addChild(SlotGroup.ofItemHandler(items,
+                 * 3).build().setPos(12, 80)) .addChild( new DropDownWidget().addDropDownItemsSimple( IntStream.range(0,
+                 * 20).boxed().map(i -> "label " + i).collect(Collectors.toList()), (buttonWidget, index, label,
+                 * setSelected) -> buttonWidget .setOnClick((clickData, widget) -> { if (!widget.isClient()) {
+                 * widget.getContext().getPlayer() .addChatMessage(new ChatComponentText("Selected " + label)); }
+                 * setSelected.run(); }), true).setExpandedMaxHeight(60).setDirection(DropDownWidget.Direction.DOWN)
+                 * .setPos(90, 30).setSize(60, 11)) .addChild( new VanillaButtonWidget()
+                 * .setDisplayString(StatCollector.translateToLocal("modularui.config.debug")) .setOnClick((clickData,
+                 * widget) -> { if (!widget.isClient()) { widget.getContext().getPlayer().addChatMessage( new
+                 * ChatComponentText(numberFormat.formatWithSuffix(longValue))); } }).setPos(70, 80).setSize(32,
+                 * 16).setInternalName("debug")) .addChild( new DrawableWidget() .setDrawable(new
+                 * FluidDrawable().setFluid(FluidRegistry.LAVA).withFixedSize(32, 16)) .setPos(70, 100).setSize(32, 16))
+                 */
 
                 .setPos(10, 10).setDebugLabel("Page1");
     }

--- a/src/main/java/com/gtnewhorizons/modularui/test/TestTile.java
+++ b/src/main/java/com/gtnewhorizons/modularui/test/TestTile.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import com.gtnewhorizons.modularui.common.widget.DynamicTextWidget;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -178,7 +179,7 @@ public class TestTile extends TileEntity implements ITileWithModularUI {
         return new MultiChildWidget().addChild(new TextWidget("Page 1"))
                 .addChild(new SlotWidget(phantomInventory, 0).setChangeListener(() -> {
                     serverCounter = 0;
-                    changeableWidget.notifyChangeServer();
+                    //changeableWidget.notifyChangeServer();
                 }).setShiftClickPriority(0).setPos(10, 30)).addChild(
                         new NumericWidget()//
                                 .setMinValue(-1_000_000)//
@@ -200,7 +201,14 @@ public class TestTile extends TileEntity implements ITileWithModularUI {
                                 .setSetter(val -> doubleValue = val)//
                                 .setTextColor(Color.WHITE.dark(1)).setBackground(DISPLAY.withOffset(-2, -2, 4, 4))
                                 .setSize(92, 20).setPos(100, 50))
-                .addChild(
+                .addChild(new TextWidget("TextWidget:\n" + numberFormat.format(System.currentTimeMillis()))
+                    .setTextAlignment(Alignment.CenterLeft).setPos(10, 80))
+                .addChild(new DynamicTextWidget(() -> new Text("DynamicTextWidget:\n" + numberFormat.format(System.currentTimeMillis())))
+                    .setTextAlignment(Alignment.CenterLeft).setPos(10, 100))
+                .addChild(new TextWidget().setStringSupplier(() -> "w/ Supplier:\n" + numberFormat.format(System.currentTimeMillis()))
+                    .setTextAlignment(Alignment.CenterLeft).setPos(10, 120))
+
+                /*.addChild(
                         SlotWidget.phantom(phantomInventory, 1).setShiftClickPriority(1).setIgnoreStackSizeLimit(true)
                                 .setControlsAmount(true).setPos(28, 30))
                 .addChild(changeableWidget.setPos(12, 55))
@@ -230,7 +238,8 @@ public class TestTile extends TileEntity implements ITileWithModularUI {
                 .addChild(
                         new DrawableWidget()
                                 .setDrawable(new FluidDrawable().setFluid(FluidRegistry.LAVA).withFixedSize(32, 16))
-                                .setPos(70, 100).setSize(32, 16))
+                                .setPos(70, 100).setSize(32, 16))*/
+
                 .setPos(10, 10).setDebugLabel("Page1");
     }
 


### PR DESCRIPTION
Simple change for a fairly complex reason. Let me explain:

This is a part of the localization effort for MUI. There are some text fields which use elements (strings, numbers) that need to be localized. Some of these elements can change their value dynamically, when the user is looking at the GUI. A simple example could be a readout: "EU stored: 1,500 / 20,000" (fictional, just for the sake of the example). This readout needs to be both translated (text "EU stored:") and localized (numbers with correct group separators).

Currently, readouts like this are handled by DynamicTextWidget. However this has a major flaw: the full string is first computed on the server, and then it is sent to the client. This will not work when the server and the client use a different locale, as the server's locale is used to build the string to display.

In reality, this does not need such a level of sophistication. We can simply build the string to display on the client, as long as the client has access to all the data it needs to do so (the current and maximum EU amounts in the example above). I have checked [all the uses](https://github.com/search?q=org%3AGTNewHorizons+AND+%28%22.dynamicText%28%22+OR+%22DynamicTextWidget%22%29&type=code) of DynamicTextWidget (there are only a couple of them in the whole pack), and this is never an issue.

I have added methods `setTextSupplier` and for convenience `setStringSupplier` to TextWidget, which will allow the displayed text to be changed from the client side, without the server being involved at all. This way, the client can also properly apply localization standards as needed. I propose also deprecating `DynamicTextWidget` and moving over all uses of it to the new methods (which I will do as a part of my ongoing localization effort).