### PR TITLE
Update NumberFormatMUI to support Object arguments.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,11 +3,11 @@
 dependencies {
     api("org.jetbrains:annotations:23.0.0")
 
-    api("com.github.GTNewHorizons:NotEnoughItems:2.5.23-GTNH:dev")
+    api("com.github.GTNewHorizons:NotEnoughItems:2.5.24-GTNH:dev")
 
     implementation("com.github.GTNewHorizons:GTNHLib:0.2.10:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Hodgepodge:2.4.34:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.45.88:dev") {
+    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.45.95:dev") {
         transitive = false
         exclude group:"com.github.GTNewHorizons", module:"ModularUI"
     }

--- a/src/main/java/com/gtnewhorizons/modularui/api/NumberFormatMUI.java
+++ b/src/main/java/com/gtnewhorizons/modularui/api/NumberFormatMUI.java
@@ -92,6 +92,17 @@ public class NumberFormatMUI extends NumberFormat {
         return baseFormat.format(number, toAppendTo, pos);
     }
 
+    public StringBuffer format(Object number, StringBuffer toAppendTo) {
+        if (currentLocale != Config.locale) refreshBaseFormat();
+        return baseFormat.format(number, toAppendTo, unusedFieldPosition);
+    }
+
+    @Override
+    public StringBuffer format(Object number, StringBuffer toAppendTo, FieldPosition pos) {
+        if (currentLocale != Config.locale) refreshBaseFormat();
+        return baseFormat.format(number, toAppendTo, pos);
+    }
+
     public static final char[] SUFFIXES = { 'k', 'M', 'G', 'T', 'P', 'E' };
 
     /**

--- a/src/test/java/com/gtnewhorizons/modularui/api/NumberFormatMUITest.java
+++ b/src/test/java/com/gtnewhorizons/modularui/api/NumberFormatMUITest.java
@@ -2,6 +2,7 @@ package com.gtnewhorizons.modularui.api;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.math.BigInteger;
 import java.text.ParseException;
 import java.util.Locale;
 
@@ -127,6 +128,16 @@ class NumberFormatMUITest {
         assertEquals("-4M", nf.formatWithSuffix(-4_000_000));
         assertEquals("-5.6M", nf.formatWithSuffix(-5_600_000));
         assertEquals("-6.7M", nf.formatWithSuffix(-6_799_999));
+    }
+
+    @Test
+    void bigInteger_Test() {
+        Config.locale = Locale.US;
+        NumberFormatMUI nf = new NumberFormatMUI();
+
+        BigInteger million = new BigInteger("1000000000");
+        BigInteger n = million.multiply(million).multiply(million);
+        assertEquals("1,000,000,000,000,000,000,000,000,000", nf.format(n));
     }
 
     @Test


### PR DESCRIPTION
In particular, this allows proper formatting of `BigInteger` and `BigDecimal` arguments, without potential loss of precision by converting to `double`.