### PR TITLE
Fix NumericWidget alignment.

### DIFF
--- a/src/main/java/com/gtnewhorizons/modularui/common/widget/textfield/NumericWidget.java
+++ b/src/main/java/com/gtnewhorizons/modularui/common/widget/textfield/NumericWidget.java
@@ -1,5 +1,6 @@
 package com.gtnewhorizons.modularui.common.widget.textfield;
 
+import java.awt.Point;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -15,7 +16,9 @@ import net.minecraft.util.MathHelper;
 import com.gtnewhorizon.gtnhlib.util.parsing.MathExpressionParser;
 import com.gtnewhorizon.gtnhlib.util.parsing.MathExpressionParser.Context;
 import com.gtnewhorizons.modularui.ModularUI;
+import com.gtnewhorizons.modularui.api.GlStateManager;
 import com.gtnewhorizons.modularui.api.NumberFormatMUI;
+import com.gtnewhorizons.modularui.api.drawable.GuiHelper;
 import com.gtnewhorizons.modularui.api.math.Alignment;
 import com.gtnewhorizons.modularui.api.widget.ISyncedWidget;
 import com.gtnewhorizons.modularui.api.widget.Interactable;
@@ -61,6 +64,21 @@ public class NumericWidget extends BaseTextFieldWidget implements ISyncedWidget 
         } else {
             handler.setPattern(NUMBER_PATTERN);
         }
+    }
+
+    @Override
+    public void draw(float partialTicks) {
+        Point draggableTranslate = getDraggableTranslate();
+        GuiHelper
+                .useScissor(pos.x + draggableTranslate.x, pos.y + draggableTranslate.y, size.width, size.height, () -> {
+                    GlStateManager.pushMatrix();
+                    GlStateManager.translate(1, 1, 0);
+                    renderer.setSimulate(false);
+                    renderer.setScale(scale);
+                    renderer.setAlignment(textAlignment, size.width - 2, size.height - 2);
+                    renderer.draw(handler.getText());
+                    GlStateManager.popMatrix();
+                });
     }
 
     public double getValue() {

--- a/src/main/java/com/gtnewhorizons/modularui/test/TestTile.java
+++ b/src/main/java/com/gtnewhorizons/modularui/test/TestTile.java
@@ -182,8 +182,9 @@ public class TestTile extends TileEntity implements ITileWithModularUI {
                                 .setSetter(val -> longValue = (long) val)//
                                 .setValidator(val -> Math.round(val / 2) * 2d)//
                                 .setScrollValues(2, 10, 1000)//
+                                .setTextAlignment(Alignment.Center)//
                                 .setTextColor(Color.WHITE.dark(1)).setBackground(DISPLAY.withOffset(-2, -2, 4, 4))
-                                .setSize(92, 20).setPos(10, 50))
+                                .setSize(80, 20).setPos(10, 50))
                 .addChild(
                         new NumericWidget()//
                                 .setIntegerOnly(false)//
@@ -192,8 +193,9 @@ public class TestTile extends TileEntity implements ITileWithModularUI {
                                 .setDefaultValue(50)//
                                 .setGetter(() -> doubleValue)//
                                 .setSetter(val -> doubleValue = val)//
+                                .setTextAlignment(Alignment.BottomRight)//
                                 .setTextColor(Color.WHITE.dark(1)).setBackground(DISPLAY.withOffset(-2, -2, 4, 4))
-                                .setSize(92, 20).setPos(100, 50))
+                                .setSize(80, 20).setPos(100, 50))
                 .addChild(
                         new TextWidget("TextWidget: " + numberFormat.format(System.currentTimeMillis() % 100_000_000))
                                 .setDefaultColor(EnumChatFormatting.WHITE).setTextAlignment(Alignment.CenterLeft)


### PR DESCRIPTION
Fixes an issue where horizontal text alignment of `NumericWidget` was ignored. (And vertical alignment was technically one pixel off.)

Thanks to @GDCloudstrike for noticing and warning me about this.