### PR TITLE
Fix capacity tooltip for tanks with void overflow enabled

### DIFF
--- a/src/main/java/com/gtnewhorizons/modularui/api/fluids/FluidTankLongDelegate.java
+++ b/src/main/java/com/gtnewhorizons/modularui/api/fluids/FluidTankLongDelegate.java
@@ -9,6 +9,8 @@ import net.minecraftforge.fluids.IFluidTank;
 
 import org.jetbrains.annotations.Nullable;
 
+import com.gtnewhorizons.modularui.common.fluid.IOverflowableTank;
+
 public class FluidTankLongDelegate implements IFluidTankLong {
 
     private final IFluidTank tank;
@@ -29,6 +31,9 @@ public class FluidTankLongDelegate implements IFluidTankLong {
 
     @Override
     public long getCapacityLong() {
+        if (tank instanceof IOverflowableTank) {
+            return ((IOverflowableTank) tank).getRealCapacity();
+        }
         return tank.getCapacity();
     }
 


### PR DESCRIPTION
Just replicates [this](https://github.com/GTNewHorizons/ModularUI/blob/master/src/main/java/com/gtnewhorizons/modularui/api/widget/FluidInteractionUtil.java#L132) which is kinda defunct now.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15631