### PR TITLE
fix AdaptableUITexture draw when drawing subArea

### DIFF
--- a/src/main/java/com/gtnewhorizons/modularui/api/drawable/AdaptableUITexture.java
+++ b/src/main/java/com/gtnewhorizons/modularui/api/drawable/AdaptableUITexture.java
@@ -74,8 +74,11 @@ public class AdaptableUITexture extends UITexture {
             super.draw(x, y, width, height);
             return;
         }
-        float borderU = borderWidthU * 1f / imageWidth;
-        float borderV = borderWidthV * 1f / imageHeight;
+        float rangeU = u1 - u0;
+        float rangeV = v1 - v0;
+
+        float borderU = borderWidthU * rangeU / imageWidth;
+        float borderV = borderWidthV * rangeV / imageHeight;
         // draw corners
         draw(location, x, y, borderWidthU, borderWidthV, u0, v0, u0 + borderU, v0 + borderV); // x0 y0
         draw(location, x + width - borderWidthU, y, borderWidthU, borderWidthV, u1 - borderU, v0, u1, v0 + borderV); // x1


### PR DESCRIPTION
I found (and was impacted by) this when modifying CRIBs to support pattern doubling and used the `CycleButtonWidget` with a size of 16.

Previously this function assumed that the u/v coordinate space was 0-1. This is not always the case when using a sub area of a texture.

Fixes the draw function to correctly calculate u/v coordinate offsets.

### Before:
![before](https://github.com/user-attachments/assets/ec23cae7-a604-4036-a804-5a5974e201bf)
(notice that the top and bottom borders are narrower than left and right)
### After:
![after](https://github.com/user-attachments/assets/1c2a7d63-56c7-4bc2-a8a1-4261e113256b)
(all borders are same width)

