### PR TITLE
Store + reapply client window pos for synced windows

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,11 +3,11 @@
 dependencies {
     api("org.jetbrains:annotations:23.0.0")
 
-    api("com.github.GTNewHorizons:NotEnoughItems:2.6.35-GTNH:dev")
+    api("com.github.GTNewHorizons:NotEnoughItems:2.6.36-GTNH:dev")
 
-    implementation("com.github.GTNewHorizons:GTNHLib:0.5.5:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Hodgepodge:2.5.60:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.49.84:dev") {
+    implementation("com.github.GTNewHorizons:GTNHLib:0.5.11:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Hodgepodge:2.5.62:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.49.103:dev") {
         transitive = false
         exclude group:"com.github.GTNewHorizons", module:"ModularUI"
     }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,11 +3,11 @@
 dependencies {
     api("org.jetbrains:annotations:23.0.0")
 
-    api("com.github.GTNewHorizons:NotEnoughItems:2.6.36-GTNH:dev")
+    api("com.github.GTNewHorizons:NotEnoughItems:2.6.38-GTNH:dev")
 
     implementation("com.github.GTNewHorizons:GTNHLib:0.5.11:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Hodgepodge:2.5.62:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.49.103:dev") {
+    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.49.111:dev") {
         transitive = false
         exclude group:"com.github.GTNewHorizons", module:"ModularUI"
     }

--- a/src/main/java/com/gtnewhorizons/modularui/api/screen/ModularUIContext.java
+++ b/src/main/java/com/gtnewhorizons/modularui/api/screen/ModularUIContext.java
@@ -271,10 +271,11 @@ public class ModularUIContext {
 
     public void storeWindowPos(ModularWindow window, Pos2d pos) {
         if (windows.contains(window)) {
-            this.lastWindowPos.put(window, pos);
             Integer id = syncedWindows.inverse().get(window);
             if (id != null) {
                 this.lastSyncedWindowPos.put(id, pos);
+            } else {
+                this.lastWindowPos.put(window, pos);
             }
         }
     }

--- a/src/main/java/com/gtnewhorizons/modularui/api/screen/ModularUIContext.java
+++ b/src/main/java/com/gtnewhorizons/modularui/api/screen/ModularUIContext.java
@@ -45,7 +45,6 @@ public class ModularUIContext {
     private final Deque<ModularWindow> windows = new LinkedList<>();
     private final BiMap<Integer, ModularWindow> syncedWindows = HashBiMap.create(4);
     private final Map<ModularWindow, Pos2d> lastWindowPos = new HashMap<>();
-    private final Map<Integer, Pos2d> lastSyncedWindowPos = new HashMap<>();
     private ModularWindow mainWindow;
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/com/gtnewhorizons/modularui/api/screen/ModularUIContext.java
+++ b/src/main/java/com/gtnewhorizons/modularui/api/screen/ModularUIContext.java
@@ -154,11 +154,6 @@ public class ModularUIContext {
                 ModularWindow newWindow = openWindow(syncedWindowsCreators.get(windowId));
                 syncedWindows.put(windowId, newWindow);
                 newWindow.onResize(screenSize);
-                if (lastSyncedWindowPos.containsKey(windowId)) {
-                    Pos2d pos = lastSyncedWindowPos.get(windowId);
-                    lastSyncedWindowPos.remove(windowId);
-                    newWindow.setPos(pos);
-                }
                 newWindow.rebuild();
                 newWindow.onOpen();
                 newWindow.initialized = true;
@@ -289,11 +284,9 @@ public class ModularUIContext {
         return false;
     }
 
-    public void storeWindowPos(int id) {
-        if (isWindowOpen(id)) {
-            ModularWindow window = this.syncedWindows.get(id);
-            this.lastSyncedWindowPos.put(id, window.getPos());
-        }
+    public boolean tryApplyStoredPos(int windowId) {
+        ModularWindow window = syncedWindows.get(windowId);
+        return window != null && tryApplyStoredPos(window);
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/com/gtnewhorizons/modularui/api/screen/ModularUIContext.java
+++ b/src/main/java/com/gtnewhorizons/modularui/api/screen/ModularUIContext.java
@@ -45,6 +45,7 @@ public class ModularUIContext {
     private final Deque<ModularWindow> windows = new LinkedList<>();
     private final BiMap<Integer, ModularWindow> syncedWindows = HashBiMap.create(4);
     private final Map<ModularWindow, Pos2d> lastWindowPos = new HashMap<>();
+    private final Map<Integer, Pos2d> lastSyncedWindowPos = new HashMap<>();
     private ModularWindow mainWindow;
 
     @SideOnly(Side.CLIENT)
@@ -153,6 +154,11 @@ public class ModularUIContext {
                 ModularWindow newWindow = openWindow(syncedWindowsCreators.get(windowId));
                 syncedWindows.put(windowId, newWindow);
                 newWindow.onResize(screenSize);
+                if (lastSyncedWindowPos.containsKey(windowId)) {
+                    Pos2d pos = lastSyncedWindowPos.get(windowId);
+                    lastSyncedWindowPos.remove(windowId);
+                    newWindow.setPos(pos);
+                }
                 newWindow.rebuild();
                 newWindow.onOpen();
                 newWindow.initialized = true;
@@ -281,6 +287,13 @@ public class ModularUIContext {
             return true;
         }
         return false;
+    }
+
+    public void storeWindowPos(int id) {
+        if (isWindowOpen(id)) {
+            ModularWindow window = this.syncedWindows.get(id);
+            this.lastSyncedWindowPos.put(id, window.getPos());
+        }
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/com/gtnewhorizons/modularui/api/screen/ModularUIContext.java
+++ b/src/main/java/com/gtnewhorizons/modularui/api/screen/ModularUIContext.java
@@ -45,6 +45,7 @@ public class ModularUIContext {
     private final Deque<ModularWindow> windows = new LinkedList<>();
     private final BiMap<Integer, ModularWindow> syncedWindows = HashBiMap.create(4);
     private final Map<ModularWindow, Pos2d> lastWindowPos = new HashMap<>();
+    private final Map<Integer, Pos2d> lastSyncedWindowPos = new HashMap<>();
     private ModularWindow mainWindow;
 
     @SideOnly(Side.CLIENT)
@@ -271,6 +272,10 @@ public class ModularUIContext {
     public void storeWindowPos(ModularWindow window, Pos2d pos) {
         if (windows.contains(window)) {
             this.lastWindowPos.put(window, pos);
+            Integer id = syncedWindows.inverse().get(window);
+            if (id != null) {
+                this.lastSyncedWindowPos.put(id, pos);
+            }
         }
     }
 
@@ -279,13 +284,14 @@ public class ModularUIContext {
         if (this.lastWindowPos.containsKey(window)) {
             window.setPos(this.lastWindowPos.get(window));
             return true;
+        } else {
+            Integer id = syncedWindows.inverse().get(window);
+            if (id != null && this.lastSyncedWindowPos.containsKey(id)) {
+                window.setPos(this.lastSyncedWindowPos.get(id));
+                return true;
+            }
         }
         return false;
-    }
-
-    public boolean tryApplyStoredPos(int windowId) {
-        ModularWindow window = syncedWindows.get(windowId);
-        return window != null && tryApplyStoredPos(window);
     }
 
     @SideOnly(Side.CLIENT)


### PR DESCRIPTION
Allows synced windows to store + reapply their position in a pattern like:
```java
context.closeWindow(x);
context.openSyncedWindow(x);
```
This is a bit of a strange fix thats necessary in some cases because synced windows use a window ID system rather than storing the ModularWindow directly and modifying it. In this case the window object isn't accessible so there is no way to get the position from the existing window or set the position on a new window outside of the context. It automatically reapplies the stored position (once) if it is stored since in the example above, the windows have to be closed on the server, and have the close synced to the client, which introduces some timing issues with when to apply the pos to the newly opened window.

I tested this in a live instance with a real UI and it works well for my use-case