### PR TITLE
Fix tessellator crash with circle draw

### DIFF
--- a/src/main/java/com/gtnewhorizons/modularui/api/drawable/shapes/Circle.java
+++ b/src/main/java/com/gtnewhorizons/modularui/api/drawable/shapes/Circle.java
@@ -76,7 +76,6 @@ public class Circle implements IDrawable {
             float angle = incr * i;
             float x = (float) (Math.sin(angle) * (width / 2) + x_2);
             float y = (float) (Math.cos(angle) * (height / 2) + y_2);
-            tessellator.startDrawing(GL11.GL_TRIANGLE_FAN);
             tessellator.setColorRGBA(
                     Color.getRed(colorOuter),
                     Color.getGreen(colorOuter),


### PR DESCRIPTION
Fix crash with Circle drawable. I think this class has never been used by anyone since this crashes every time it's drawn

Stacktrace:
```
java.lang.IllegalStateException: Already tesselating!
	at net.minecraft.client.renderer.Tessellator.startDrawing(Tessellator.java:257)
	at com.gtnewhorizons.modularui.api.drawable.shapes.Circle.draw(Circle.java:79)
	at com.gtnewhorizons.modularui.api.drawable.IDrawable.draw(IDrawable.java:42)
	at com.gtnewhorizons.modularui.common.widget.DrawableWidget.draw(DrawableWidget.java:47)
	at com.gtnewhorizons.modularui.api.widget.Widget.drawInternal(Widget.java:261)
	at com.gtnewhorizons.modularui.api.widget.Widget.drawInternal(Widget.java:237)
	at com.gtnewhorizons.modularui.api.widget.IWidgetParent.drawChildren(IWidgetParent.java:47)
	at com.gtnewhorizons.modularui.api.widget.Widget.drawInternal(Widget.java:265)
	at com.gtnewhorizons.modularui.api.widget.Widget.drawInternal(Widget.java:237)
	at com.gtnewhorizons.modularui.api.screen.ModularWindow.drawWidgets(ModularWindow.java:298)
	at com.gtnewhorizons.modularui.common.internal.wrapper.ModularGui.drawGuiContainerBackgroundLayer(ModularGui.java:276)
	at com.gtnewhorizons.modularui.common.internal.wrapper.ModularGui.drawScreen(ModularGui.java:128)
```