### PR TITLE
Fix NEI item zoom with multiple mui windows

### DIFF
--- a/src/main/java/com/gtnewhorizons/modularui/integration/nei/ModularUIContainerObjectHandler.java
+++ b/src/main/java/com/gtnewhorizons/modularui/integration/nei/ModularUIContainerObjectHandler.java
@@ -3,9 +3,11 @@ package com.gtnewhorizons.modularui.integration.nei;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 
+import com.gtnewhorizons.modularui.api.screen.ModularWindow;
 import com.gtnewhorizons.modularui.api.widget.IHasStackUnderMouse;
 import com.gtnewhorizons.modularui.api.widget.Widget;
 import com.gtnewhorizons.modularui.common.internal.wrapper.ModularGui;
+import com.gtnewhorizons.modularui.common.widget.SlotWidget;
 
 import codechicken.nei.guihook.IContainerObjectHandler;
 
@@ -33,6 +35,23 @@ public class ModularUIContainerObjectHandler implements IContainerObjectHandler 
 
     @Override
     public boolean objectUnderMouse(GuiContainer gui, int mousex, int mousey) {
+        if (gui instanceof ModularGui) {
+            ModularGui modularGui = (ModularGui) gui;
+            ModularWindow hoveredWindow = modularGui.getCursor().findHoveredWindow();
+
+            boolean foundLowerSlot = false;
+            for (Object hovered : modularGui.getCursor().getAllHovered()) {
+                if (hovered instanceof SlotWidget) {
+                    SlotWidget slot = (SlotWidget) hovered;
+                    if (slot.getWindow() == hoveredWindow) {
+                        return false;
+                    } else {
+                        foundLowerSlot = true;
+                    }
+                }
+            }
+            return foundLowerSlot;
+        }
         return false;
     }
 


### PR DESCRIPTION
Fixes NEI item zoom finding an item to render from an MUI slot obscured by a window above

Old:
https://github.com/user-attachments/assets/2c98693d-a772-46f9-af8e-defce6ea307a

New:
https://github.com/user-attachments/assets/a4794890-1526-4698-9f6c-ba2ae7062788


