### PR TITLE
Fix FluidSlotWidget fluidChanged detect

### DIFF
--- a/src/main/java/com/gtnewhorizons/modularui/api/fluids/FluidTankLong.java
+++ b/src/main/java/com/gtnewhorizons/modularui/api/fluids/FluidTankLong.java
@@ -21,7 +21,6 @@ public class FluidTankLong implements IFluidTankLong {
     private long capacity;
     private FluidStack internal;
     private boolean locked;
-    private int lastFluidAmountInStack;
     private NBTTagCompound tag;
 
     public FluidTankLong(Fluid fluid, long capacity, long amount) {
@@ -53,7 +52,6 @@ public class FluidTankLong implements IFluidTankLong {
             fluid = null;
             internal = null;
             storedAmount = 0;
-            lastFluidAmountInStack = 0;
             return null;
         }
 
@@ -61,12 +59,7 @@ public class FluidTankLong implements IFluidTankLong {
             internal = new FluidStack(fluid, 0);
         }
 
-        if (internal.amount != lastFluidAmountInStack) {
-            storedAmount -= lastFluidAmountInStack - internal.amount;
-        }
-
         internal.amount = saturatedCast(storedAmount);
-        lastFluidAmountInStack = internal.amount;
         return internal;
     }
 
@@ -135,11 +128,9 @@ public class FluidTankLong implements IFluidTankLong {
         storedAmount = amount;
         if (fluid == null) {
             internal = null;
-            lastFluidAmountInStack = 0;
             return;
         }
         internal = new FluidStack(this.fluid, saturatedCast(storedAmount));
-        lastFluidAmountInStack = saturatedCast(storedAmount);
     }
 
     public void setFluid(Fluid fluid) {


### PR DESCRIPTION
This is originally found because I'm working on an enhanced fluid tank in GT.
Because the fluid value is kept updated from `SWidgetUpdate`, I think there must be something wrong.

Then I found that in the method `FluidSlotWidget#fluidChanged`,
the `cached` value is also kept changing, whose fluid amount is jumping from _x_ B to _2x_ B then back (eg 64B lava to 128B then 64B).

The true cause of the amount changing is the line in `FluidTankLong#getFluidStack()`, which the function is called in `isFluidEqual`:

```
if (internal.amount != lastFluidAmountInStack) {
    storedAmount -= lastFluidAmountInStack - internal.amount;
}
```

for example, `storedAmount` is 64B, but the `lastFluidAmountInStack` is 0, then it makes the amount added to 128B.

I'm not sure what does this `lastFluidAmountInStack` do, but removing it fixes this problem.
