### PR TITLE
[Memory-opti:fix leak] Fix memory leak in ModularUIContext

### DIFF
--- a/src/main/java/com/gtnewhorizons/modularui/ClientProxy.java
+++ b/src/main/java/com/gtnewhorizons/modularui/ClientProxy.java
@@ -4,6 +4,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.IResourceManager;
 import net.minecraft.client.resources.IResourceManagerReloadListener;
 import net.minecraft.client.resources.SimpleReloadableResourceManager;
+import net.minecraft.entity.player.EntityPlayer;
 
 import com.gtnewhorizons.modularui.api.drawable.FallbackableUITexture;
 import com.gtnewhorizons.modularui.common.internal.JsonLoader;
@@ -30,6 +31,11 @@ public class ClientProxy extends CommonProxy {
         super.postInit();
         ((SimpleReloadableResourceManager) Minecraft.getMinecraft().getResourceManager())
                 .registerReloadListener(new ResourceManagerReloadListener());
+    }
+
+    @Override
+    public EntityPlayer getClientPlayer() {
+        return Minecraft.getMinecraft().thePlayer;
     }
 
     private static class ResourceManagerReloadListener implements IResourceManagerReloadListener {

--- a/src/main/java/com/gtnewhorizons/modularui/CommonProxy.java
+++ b/src/main/java/com/gtnewhorizons/modularui/CommonProxy.java
@@ -3,6 +3,7 @@ package com.gtnewhorizons.modularui;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.common.MinecraftForge;
 
 import com.gtnewhorizons.modularui.config.Config;
@@ -40,5 +41,9 @@ public class CommonProxy {
         if (event.modID.equals(ModularUI.MODID)) {
             Config.syncConfig();
         }
+    }
+
+    public EntityPlayer getClientPlayer() {
+        return null;
     }
 }

--- a/src/main/java/com/gtnewhorizons/modularui/api/screen/ModularUIContext.java
+++ b/src/main/java/com/gtnewhorizons/modularui/api/screen/ModularUIContext.java
@@ -51,7 +51,7 @@ public class ModularUIContext {
     @SideOnly(Side.CLIENT)
     private ModularGui screen;
 
-    private final EntityPlayer player;
+    private final EntityPlayer playerMP;
     private final Cursor cursor;
     private final List<Integer> queuedOpenWindow = new ArrayList<>();
     public final boolean clientOnly;
@@ -72,10 +72,10 @@ public class ModularUIContext {
     }
 
     public ModularUIContext(UIBuildContext context, Runnable onWidgetUpdate, boolean clientOnly) {
-        this.player = context.player;
         if (!isClient() && clientOnly) {
             throw new IllegalArgumentException("Client only ModularUI can not be opened on server!");
         }
+        this.playerMP = context.player instanceof EntityPlayerMP ? context.player : null;
         this.clientOnly = clientOnly;
         this.syncedWindowsCreators = context.syncedWindows.build();
         this.cursor = new Cursor(this);
@@ -194,7 +194,7 @@ public class ModularUIContext {
     }
 
     public ModularWindow openWindow(IWindowCreator windowCreator) {
-        ModularWindow window = windowCreator.create(player);
+        ModularWindow window = windowCreator.create(this.getPlayer());
         pushWindow(window);
         return window;
     }
@@ -258,7 +258,7 @@ public class ModularUIContext {
     }
 
     public void close() {
-        player.closeScreen();
+        this.getPlayer().closeScreen();
     }
 
     public void closeAllButMain() {
@@ -305,7 +305,10 @@ public class ModularUIContext {
     }
 
     public EntityPlayer getPlayer() {
-        return player;
+        if (this.playerMP != null) {
+            return this.playerMP;
+        }
+        return ModularUI.proxy.getClientPlayer();
     }
 
     public ModularUIContainer getContainer() {
@@ -406,7 +409,7 @@ public class ModularUIContext {
         ModularWindow window = syncedWindows.get(windowId);
         if (widgetId == DataCodes.INTERNAL_SYNC) {
             if (id == DataCodes.SYNC_CURSOR_STACK) {
-                player.inventory.setItemStack(NetworkUtils.readItemStack(buf));
+                this.getPlayer().inventory.setItemStack(NetworkUtils.readItemStack(buf));
             } else if (id == DataCodes.OPEN_WINDOW) {
                 queuedOpenWindow.add(buf.readVarIntFromBuffer());
             } else if (id == DataCodes.CLOSE_WINDOW) {
@@ -457,7 +460,7 @@ public class ModularUIContext {
             buffer.writeVarIntToBuffer(syncedWindows.inverse().get(window));
             bufferConsumer.accept(buffer);
             SWidgetUpdate packet = new SWidgetUpdate(buffer, syncId);
-            NetworkHandler.sendToPlayer(packet, (EntityPlayerMP) player);
+            NetworkHandler.sendToPlayer(packet, (EntityPlayerMP) this.getPlayer());
         }
     }
 


### PR DESCRIPTION
This class is used for all the GT NEI Handler so it creates tons of leaks.
Tried it in fullpack, loaded a world, clicked everywhere in NEI, closed the world, load another save, clicked everywhere in NEI, changed dimensions do it again
Did not spot anything wrong

<img width="527" height="188" alt="image" src="https://github.com/user-attachments/assets/c6de8974-8cd5-43b4-9688-66647e64dfa7" />
